### PR TITLE
feat: parametrize elb health check thresholds FGR3-2163

### DIFF
--- a/terraform-ecs-fargate-service/service.tf
+++ b/terraform-ecs-fargate-service/service.tf
@@ -67,8 +67,8 @@ resource "aws_alb_target_group" "ecs_service_target_group" {
   deregistration_delay = 30
 
   health_check {
-    healthy_threshold = 5
-    unhealthy_threshold = 2
+    healthy_threshold = var.load_balancer_health_check_healthy_threshold
+    unhealthy_threshold = var.load_balancer_health_check_unhealthy_threshold
     interval = 30
     matcher = 200
     path = var.load_balancer_health_check_path

--- a/terraform-ecs-fargate-service/variables.tf
+++ b/terraform-ecs-fargate-service/variables.tf
@@ -32,6 +32,17 @@ variable "load_balancer_listener_rule_path_patterns" {
 variable "load_balancer_health_check_path" {
     type = string
 }
+
+variable "load_balancer_health_check_healthy_threshold" {
+    type = number
+    default = 5
+}
+
+variable "load_balancer_health_check_unhealthy_threshold" {
+    type = number
+    default = 2
+}
+
 variable "ecr_repository_url" {
     type = string
 }


### PR DESCRIPTION
`figure-backend` má specifický `unhealthy_threshold` (https://github.com/FigurePOS/figure-backend/blob/ecb5d82268ded4a28db910578aef0d9f4b568985/tf/ecs_fargate_service/service.tf#L56), tak bych ty thresholdy parametrizoval raději rovnou oba.