### PR TITLE
feat: output elb target group arn FGR3-2163

### DIFF
--- a/terraform-ecs-fargate-service/service.tf
+++ b/terraform-ecs-fargate-service/service.tf
@@ -104,3 +104,7 @@ resource "aws_alb_listener_rule" "ecs_alb_listener_rule" {
     ]
   }
 }
+
+output "elb_target_group_arn" {
+  value = aws_alb_target_group.ecs_service_target_group.arn
+}


### PR DESCRIPTION
Potřebuju exposnout arn target groupy load balanceru, protože `make-it-butter-api` má [jednu custom rule navíc](https://github.com/FigurePOS/make-it-butter-api/blob/0b82ca2303f0c8b0b128d530fe6dc0f1febcec5b/tf/ecs_fargate_service/service.tf#L87-L105), tak ta arn je potřeba k tomu aby ji šlo dodefinovat.