### PR TITLE
fix: ignore tags changes on aws_appautoscaling_target FGR3-2228

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @FigurePOS/platform

--- a/terraform-ecs-fargate-autoscaling-basic/autoscaling.tf
+++ b/terraform-ecs-fargate-autoscaling-basic/autoscaling.tf
@@ -9,6 +9,14 @@ resource "aws_appautoscaling_target" "target" {
   scalable_dimension = "ecs:service:DesiredCount"
   min_capacity = var.min_capacity
   max_capacity = var.max_capacity
+
+  lifecycle {
+    # see https://github.com/hashicorp/terraform-provider-aws/issues/31261
+    ignore_changes = [
+      tags,
+      tags_all
+    ]
+  }
 }
 
 resource "aws_appautoscaling_policy" "up" {


### PR DESCRIPTION
viz. <img width="1411" alt="CleanShot 2023-08-28 at 10 07 54@2x" src="https://github.com/FigurePOS/terraform-modules/assets/215660/d4f887ac-4466-4ea5-9339-30a19f6dcef9">

 https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_target.html
<img width="703" alt="CleanShot 2023-08-28 at 10 06 59@2x" src="https://github.com/FigurePOS/terraform-modules/assets/215660/aa237747-4104-4e48-9dbe-0fe16fe294a5">
