### PR TITLE
feat: add dd monitor for increased messages in dead letter queue FGR3-2572

### DIFF
--- a/terraform-datadog-sqs/main.tf
+++ b/terraform-datadog-sqs/main.tf
@@ -2,31 +2,53 @@ locals {
   identifierLabel = var.identifier != "" ? "(${var.identifier})" : ""
 }
 
+data "datadog_role" "admin_role" {
+  filter = "Admin"
+}
+
 resource "datadog_monitor" "sqs_number_of_messages_monitor" {
-  name = trimspace("${var.service_name_readable} – SQS - Number of messages ${local.identifierLabel}")
-  count = var.env == "production" ? 1 : 0
-  locked = true
-  tags = var.tags
-  type = "metric alert"
+  name             = trimspace("${var.service_name_readable} – SQS - Total number of messages ${local.identifierLabel}")
+  count            = var.env == "production" ? 1 : 0
+  restricted_roles = [data.datadog_role.admin_role.id]
+  tags             = var.tags
+
+  type    = "metric alert"
   message = var.message
-  query = "min(last_5m):avg:aws.sqs.approximate_number_of_messages_visible{queuename:${lower(var.queue_name)},env:${var.env}} > ${var.queue_messages_critical}"
+  query   = "min(last_5m):avg:aws.sqs.approximate_number_of_messages_visible{queuename:${lower(var.queue_name)},env:${var.env}} > ${var.queue_messages_critical}"
   monitor_thresholds {
-    warning = var.queue_messages_warning
+    warning  = var.queue_messages_warning
     critical = var.queue_messages_critical
   }
 }
 
 resource "datadog_monitor" "sqs_number_of_messages_dead_letter_monitor" {
-  name = trimspace("${var.service_name_readable} – SQS - Number of messages in dead letter ${local.identifierLabel}")
-  count = var.env == "production" ? 1 : 0
-  locked = true
-  tags = var.tags
-  type = "metric alert"
-  message = var.message
-  query = "min(last_5m):avg:aws.sqs.approximate_number_of_messages_visible{queuename:${lower(var.dead_letter_queue_name)},env:${var.env}} > ${var.dead_letter_queue_messages_critical}"
+  name             = trimspace("${var.service_name_readable} – SQS - Total number of messages in dead letter ${local.identifierLabel}")
+  count            = var.env == "production" ? 1 : 0
+  restricted_roles = [data.datadog_role.admin_role.id]
+  tags             = var.tags
+
+  type    = "metric alert"
+  message = var.message_slack
+  query   = "min(last_5m):avg:aws.sqs.approximate_number_of_messages_visible{queuename:${lower(var.dead_letter_queue_name)},env:${var.env}} > ${var.dead_letter_queue_messages_critical}"
   monitor_thresholds {
-    warning = var.dead_letter_queue_messages_warning
+    warning  = var.dead_letter_queue_messages_warning
     critical = var.dead_letter_queue_messages_critical
   }
   renotify_interval = var.dead_letter_queue_renotify_interval
+}
+
+resource "datadog_monitor" "sqs_increased_number_of_messages_dead_letter_monitor" {
+  name             = trimspace("${var.service_name_readable} – SQS - Increased number of messages in dead letter ${local.identifierLabel}")
+  count            = var.env == "production" ? 1 : 0
+  restricted_roles = [data.datadog_role.admin_role.id]
+  tags             = var.tags
+
+  type    = "metric alert"
+  message = var.message_opsgenie
+  # the query means positive change in amount of messages in last five minutes
+  query = "avg(last_1h):monotonic_diff(aws.sqs.approximate_number_of_messages_visible{queuename:${lower(var.dead_letter_queue_name)},env:${var.env}}.rollup(avg, 300)) > ${var.dead_letter_queue_increased_messages_critical}"
+  monitor_thresholds {
+    critical = var.dead_letter_queue_increased_messages_critical
+  }
+  renotify_interval = var.dead_letter_queue_increased_renotify_interval
 }

--- a/terraform-datadog-sqs/variables.tf
+++ b/terraform-datadog-sqs/variables.tf
@@ -25,6 +25,16 @@ variable "identifier" {
   default = ""
 }
 
+variable "message_slack" {
+  type = string
+  default = "@slack-figure-alerts"
+}
+
+variable "message_opsgenie" {
+  type = string
+  default = "{{#is_alert}}@opsgenie{{/is_alert}} {{#is_recovery}}@opsgenie{{/is_recovery}}"
+}
+
 variable "message" {
   type = string
   default = "@slack-figure-alerts {{#is_alert}}@opsgenie{{/is_alert}} {{#is_recovery}}@opsgenie{{/is_recovery}}"
@@ -51,6 +61,22 @@ variable "dead_letter_queue_messages_critical" {
 }
 
 variable "dead_letter_queue_renotify_interval" {
+  type = number
+  default = 24 * 60
+}
+
+
+variable "dead_letter_queue_increased_messages_warning" {
+  type = number
+  default = 0
+}
+
+variable "dead_letter_queue_increased_messages_critical" {
+  type = number
+  default = 20
+}
+
+variable "dead_letter_queue_increased_renotify_interval" {
   type = number
   default = 24 * 60
 }


### PR DESCRIPTION
Přidal jsem monitor, který zavolá OpsGenie pokud nárůst zpráv v DLQ za posledních pět minut přesáhne 20, jak jsme se bavili. 

Původní monitor na celkový počet zpráv jsem nechal s tím, že jen píše do Slacku. Rád bych to upravil tak, že vytvoří DD incident který bude low-prio a assignuje se odpovídajícímu týmu. Ale vypadá to, že v DD jdou snad incidenty zakládat jen manuálně v UI nebo ze Slacku. 🤔 To je divný, ale nechci tím teď ztrácet čas, napsal jsem na to issue.

`locked` property je deprekovaná, místo ní je tam ta `restricted_roles` s referencí na id admin role přes `data`.