### PR TITLE
fix: remove warning from total number of DLQ messages FGR3-2572

### DIFF
--- a/terraform-datadog-sqs/main.tf
+++ b/terraform-datadog-sqs/main.tf
@@ -31,7 +31,6 @@ resource "datadog_monitor" "sqs_number_of_messages_dead_letter_monitor" {
   message = var.message_slack
   query   = "min(last_5m):avg:aws.sqs.approximate_number_of_messages_visible{queuename:${lower(var.dead_letter_queue_name)},env:${var.env}} > ${var.dead_letter_queue_messages_critical}"
   monitor_thresholds {
-    warning  = var.dead_letter_queue_messages_warning
     critical = var.dead_letter_queue_messages_critical
   }
   renotify_interval = var.dead_letter_queue_renotify_interval

--- a/terraform-datadog-sqs/variables.tf
+++ b/terraform-datadog-sqs/variables.tf
@@ -50,11 +50,6 @@ variable "queue_messages_critical" {
   default = 100
 }
 
-variable "dead_letter_queue_messages_warning" {
-  type = number
-  default = 0
-}
-
 variable "dead_letter_queue_messages_critical" {
   type = number
   default = 50
@@ -63,12 +58,6 @@ variable "dead_letter_queue_messages_critical" {
 variable "dead_letter_queue_renotify_interval" {
   type = number
   default = 24 * 60
-}
-
-
-variable "dead_letter_queue_increased_messages_warning" {
-  type = number
-  default = 0
 }
 
 variable "dead_letter_queue_increased_messages_critical" {


### PR DESCRIPTION
Myslím že ten warning na total number of messages (tj. ten co se neposílá do Opsgenie) můžeme úplně oddělat? Navíc je tam problém s tou default nulou že se nebere jako undefined ale opravdu jako nula:
![CleanShot 2023-09-26 at 11 59 11](https://github.com/FigurePOS/terraform-modules/assets/215660/c63c230b-4d5e-4104-ad85-4646d55b92cd)
