### PR TITLE
refactor: tf format + remove obsolete locked property + do not use _readable_ service names FGR3-2585

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+# Figure terraform modules
+
+## terraform-datadog-ecs-service
+
+Creates Datadog monitors for CPU and Memory utilization of ECS Service.
+
+
+## terraform-datadog-metric-slo
+
+Creates Datadog metric monitor and SLO.
+
+
+## terraform-datadog-slo-event-handler
+
+Creates Datadog metric monitor and SLO for event handlers.
+
+
+## terraform-datadog-slo-express-endpoint
+
+Creates Datadog metric monitor and SLO for Rest API endpoints.
+
+
+## terraform-datadog-slo-graphql-endpoint
+
+Creates Datadog metric monitor and SLO for GraphQL endpoints.
+
+
+## terraform-datadog-sqs
+
+Creates Datadog metric monitors for number of messages in SQS queue and its DLQ.
+
+
+## terraform-ecs-fargate-autoscaling-basic
+
+Creates autoscaling policy for ECS task based on CPU utilization.
+
+
+## terraform-ecs-fargate-service
+
+Creates ECS Fargate service and load balancer.

--- a/terraform-datadog-ecs-service/main.tf
+++ b/terraform-datadog-ecs-service/main.tf
@@ -1,28 +1,32 @@
-
+data "datadog_role" "admin_role" {
+  filter = "Admin"
+}
 resource "datadog_monitor" "ecs_cpu_monitor" {
-  name = "${var.service_name_readable} – ECS – CPU utilization"
-  count = var.env == "production" ? 1 : 0
-  type = "metric alert"
+  name    = "${var.service_name} – ECS – CPU utilization"
+  count   = var.env == "production" ? 1 : 0
+  type    = "metric alert"
   message = var.message
-  query = "min(${var.interval}):avg:aws.ecs.service.cpuutilization{servicename:${var.service_name},env:${var.env}} > ${var.cpu_critical}"
+  query   = "min(${var.interval}):avg:aws.ecs.service.cpuutilization{servicename:${var.service_name},env:${var.env}} > ${var.cpu_critical}"
   monitor_thresholds {
-    warning = var.cpu_warning
+    warning  = var.cpu_warning
     critical = var.cpu_critical
   }
-  locked = true
-  tags = var.tags
+
+  restricted_roles = [data.datadog_role.admin_role.id]
+  tags             = var.tags
 }
 
 resource "datadog_monitor" "ecs_memory_monitor" {
-  name = "${var.service_name_readable} – ECS – Memory utilization"
-  count = var.env == "production" ? 1 : 0
-  type = "metric alert"
+  name    = "${var.service_name} – ECS – Memory utilization"
+  count   = var.env == "production" ? 1 : 0
+  type    = "metric alert"
   message = var.message
-  query = "min(${var.interval}):avg:aws.ecs.service.memory_utilization{servicename:${var.service_name},env:${var.env}} > ${var.memory_critical}"
+  query   = "min(${var.interval}):avg:aws.ecs.service.memory_utilization{servicename:${var.service_name},env:${var.env}} > ${var.memory_critical}"
   monitor_thresholds {
-    warning = var.memory_warning
+    warning  = var.memory_warning
     critical = var.memory_critical
   }
-  locked = true
-  tags = var.tags
+
+  restricted_roles = [data.datadog_role.admin_role.id]
+  tags             = var.tags
 }

--- a/terraform-datadog-ecs-service/variables.tf
+++ b/terraform-datadog-ecs-service/variables.tf
@@ -7,41 +7,37 @@ variable "service_name" {
   type = string
 }
 
-variable "service_name_readable" {
-  type = string
-}
-
 variable "tags" {
-  type = list(string)
+  type    = list(string)
   default = []
 }
 
 variable "message" {
-  type = string
+  type    = string
   default = "@slack-figure-alerts {{#is_alert}}@opsgenie{{/is_alert}} {{#is_recovery}}@opsgenie{{/is_recovery}}"
 }
 
 variable "cpu_warning" {
-  type = number
+  type    = number
   default = 80
 }
 
 variable "cpu_critical" {
-  type = number
+  type    = number
   default = 95
 }
 
 variable "memory_warning" {
-  type = number
+  type    = number
   default = 80
 }
 
 variable "memory_critical" {
-  type = number
+  type    = number
   default = 95
 }
 
 variable "interval" {
-  type = string
+  type    = string
   default = "last_10m"
 }

--- a/terraform-datadog-metric-slo/main.tf
+++ b/terraform-datadog-metric-slo/main.tf
@@ -1,15 +1,19 @@
+data "datadog_role" "admin_role" {
+  filter = "Admin"
+}
 
 resource "datadog_monitor" "monitor" {
-  name = var.monitor_name
-  locked = true
-  tags = var.tags
-  type = "metric alert"
+  name    = var.monitor_name
+  tags    = var.tags
+  type    = "metric alert"
   message = var.monitor_message
-  query = "${var.monitor_eval_fn}(${var.monitor_eval_interval}):${var.monitor_query} > ${var.monitor_threshold}"
+  query   = "${var.monitor_eval_fn}(${var.monitor_eval_interval}):${var.monitor_query} > ${var.monitor_threshold}"
   monitor_thresholds {
-    warning = var.monitor_threshold / 2
+    warning  = var.monitor_threshold / 2
     critical = var.monitor_threshold
   }
+
+  restricted_roles = [data.datadog_role.admin_role.id]
 }
 
 resource "datadog_service_level_objective" "slo" {
@@ -22,9 +26,10 @@ resource "datadog_service_level_objective" "slo" {
     for_each = var.slo_thresholds
     content {
       timeframe = thresholds.value.timeframe
-      target = thresholds.value.target
+      target    = thresholds.value.target
     }
   }
+
   tags = var.tags
 }
 

--- a/terraform-datadog-metric-slo/variables.tf
+++ b/terraform-datadog-metric-slo/variables.tf
@@ -1,6 +1,6 @@
 
 variable "tags" {
-  type = list(string)
+  type    = list(string)
   default = []
 }
 
@@ -13,12 +13,12 @@ variable "monitor_message" {
 }
 
 variable "monitor_eval_interval" {
-  type = string
+  type    = string
   default = "last_5m"
 }
 
 variable "monitor_eval_fn" {
-  type = string
+  type    = string
   default = "max"
 }
 
@@ -35,5 +35,5 @@ variable "slo_name" {
 }
 
 variable "slo_thresholds" {
-  type = list(object({ timeframe: string, target: number }))
+  type = list(object({ timeframe : string, target : number }))
 }

--- a/terraform-datadog-slo-event-handler/main.tf
+++ b/terraform-datadog-slo-event-handler/main.tf
@@ -1,35 +1,41 @@
 
 locals {
   monitor_dimensions = "env:${var.env},resource_name:${lower(var.resource_name)},service:${var.service}"
-  metric_latency = "${var.latency_percentile}:trace.figure.message.consumer{${local.monitor_dimensions}}"
+  metric_latency     = "${var.latency_percentile}:trace.figure.message.consumer{${local.monitor_dimensions}}"
+}
+
+data "datadog_role" "admin_role" {
+  filter = "Admin"
 }
 
 resource "datadog_monitor" "apm_monitor_latency" {
-  name = "${var.service_name_readable} – APM - ${var.resource_name} – Latency (${var.latency_percentile}) is over ${var.latency_target}s"
-  count = var.env == "production" ? 1 : 0
-  type = "metric alert"
-  message = var.message
-  query = "${var.eval_fn}(${var.interval}):${local.metric_latency} > ${var.latency_target}"
-  tags = var.tags
-  locked = true
+  name           = "${var.service_name} – APM - ${var.resource_name} – Latency (${var.latency_percentile}) is over ${var.latency_target}s"
+  count          = var.env == "production" ? 1 : 0
+  type           = "metric alert"
+  message        = var.message
+  query          = "${var.eval_fn}(${var.interval}):${local.metric_latency} > ${var.latency_target}"
   notify_no_data = var.notify_on_missing_data
+
+  restricted_roles = [data.datadog_role.admin_role.id]
+  tags             = var.tags
 }
 
 resource "datadog_service_level_objective" "apm_slo_latency" {
-  name = "${var.service_name_readable} – APM - ${var.resource_name} – Latency"
+  name  = "${var.service_name} – APM - ${var.resource_name} – Latency"
   count = var.env == "production" ? 1 : 0
-  type = "monitor"
+  type  = "monitor"
   monitor_ids = [
     datadog_monitor.apm_monitor_latency[0].id
   ]
   thresholds {
     timeframe = "30d"
-    target = var.slo_latency_target
+    target    = var.slo_latency_target
   }
   thresholds {
     timeframe = "90d"
-    target = var.slo_latency_target
+    target    = var.slo_latency_target
   }
+
   tags = var.tags
 }
 

--- a/terraform-datadog-slo-event-handler/variables.tf
+++ b/terraform-datadog-slo-event-handler/variables.tf
@@ -11,7 +11,7 @@ variable "resource_name" {
   type = string
 }
 
-variable "service_name_readable" {
+variable "service_name" {
   type = string
 }
 

--- a/terraform-datadog-slo-express-endpoint/main.tf
+++ b/terraform-datadog-slo-express-endpoint/main.tf
@@ -1,65 +1,73 @@
 
 locals {
   monitor_dimensions = "env:${var.env},resource_name:${lower(var.resource_name)},service:${var.service}"
-  metric_errors = "sum:trace.express.request.errors{${local.monitor_dimensions}}.as_rate().rollup(sum,60)"
-  metric_hits = "sum:trace.express.request.hits{${local.monitor_dimensions}}.as_rate().rollup(sum,60)"
-  metric_latency = "${var.latency_percentile}:trace.express.request{${local.monitor_dimensions}}"
+  metric_errors      = "sum:trace.express.request.errors{${local.monitor_dimensions}}.as_rate().rollup(sum,60)"
+  metric_hits        = "sum:trace.express.request.hits{${local.monitor_dimensions}}.as_rate().rollup(sum,60)"
+  metric_latency     = "${var.latency_percentile}:trace.express.request{${local.monitor_dimensions}}"
+}
+
+data "datadog_role" "admin_role" {
+  filter = "Admin"
 }
 
 resource "datadog_monitor" "apm_monitor_error_rate" {
-  name = "${var.service_name_readable} – APM - ${var.resource_name_readable} – Error rate is over ${var.error_rate_target}%"
-  count = var.env == "production" ? 1 : 0
-  type = "metric alert"
+  name    = "${var.service_name} – APM - ${var.resource_name} – Error rate is over ${var.error_rate_target}%"
+  count   = var.env == "production" ? 1 : 0
+  type    = "metric alert"
   message = var.message
-  query = "${var.eval_fn}(${var.interval}):(100 * ${local.metric_errors} / ${local.metric_hits}) > ${var.error_rate_target}"
-  tags = var.tags
-  locked = true
+  query   = "${var.eval_fn}(${var.interval}):(100 * ${local.metric_errors} / ${local.metric_hits}) > ${var.error_rate_target}"
+
+  restricted_roles = [data.datadog_role.admin_role.id]
+  tags             = var.tags
 }
 
 resource "datadog_service_level_objective" "apm_slo_error_rate" {
-  name = "${var.service_name_readable} – APM - ${var.resource_name_readable} – Error rate"
+  name  = "${var.service_name} – APM - ${var.resource_name} – Error rate"
   count = var.env == "production" ? 1 : 0
-  type = "monitor"
+  type  = "monitor"
   monitor_ids = [
     datadog_monitor.apm_monitor_error_rate[0].id
   ]
   thresholds {
     timeframe = "30d"
-    target = var.slo_error_rate_target
+    target    = var.slo_error_rate_target
   }
   thresholds {
     timeframe = "90d"
-    target = var.slo_error_rate_target
+    target    = var.slo_error_rate_target
   }
+
   tags = var.tags
 }
 
 resource "datadog_monitor" "apm_monitor_latency" {
-  name = "${var.service_name_readable} – APM - ${var.resource_name_readable} – Latency (${var.latency_percentile}) is over ${var.latency_target}s"
-  count = var.env == "production" ? 1 : 0
-  type = "metric alert"
-  message = var.message
-  query = "${var.eval_fn}(${var.interval}):${local.metric_latency} > ${var.latency_target}"
-  tags = var.tags
-  locked = true
+  name           = "${var.service_name} – APM - ${var.resource_name} – Latency (${var.latency_percentile}) is over ${var.latency_target}s"
+  count          = var.env == "production" ? 1 : 0
+  type           = "metric alert"
+  message        = var.message
+  query          = "${var.eval_fn}(${var.interval}):${local.metric_latency} > ${var.latency_target}"
   notify_no_data = var.notify_on_missing_data
+
+  restricted_roles = [data.datadog_role.admin_role.id]
+  tags             = var.tags
 }
 
 resource "datadog_service_level_objective" "apm_slo_latency" {
-  name = "${var.service_name_readable} – APM - ${var.resource_name_readable} – Latency"
+  name  = "${var.service_name} – APM - ${var.resource_name} – Latency"
   count = var.env == "production" ? 1 : 0
-  type = "monitor"
+  type  = "monitor"
   monitor_ids = [
     datadog_monitor.apm_monitor_latency[0].id
   ]
   thresholds {
     timeframe = "30d"
-    target = var.slo_latency_target
+    target    = var.slo_latency_target
   }
   thresholds {
     timeframe = "90d"
-    target = var.slo_latency_target
+    target    = var.slo_latency_target
   }
+
   tags = var.tags
 }
 

--- a/terraform-datadog-slo-express-endpoint/variables.tf
+++ b/terraform-datadog-slo-express-endpoint/variables.tf
@@ -11,11 +11,7 @@ variable "resource_name" {
   type = string
 }
 
-variable "service_name_readable" {
-  type = string
-}
-
-variable "resource_name_readable" {
+variable "service_name" {
   type = string
 }
 

--- a/terraform-datadog-slo-graphql-endpoint/main.tf
+++ b/terraform-datadog-slo-graphql-endpoint/main.tf
@@ -1,65 +1,73 @@
 
 locals {
   monitor_dimensions = "env:${var.env},resource_name:${lower(var.resource_name)},service:${var.service}"
-  metric_errors = "sum:trace.graphql.execute.errors{${local.monitor_dimensions}}.as_rate().rollup(sum,60)"
-  metric_hits = "sum:trace.graphql.execute.hits{${local.monitor_dimensions}}.as_rate().rollup(sum,60)"
-  metric_latency = "${var.latency_percentile}:trace.graphql.execute{${local.monitor_dimensions}}"
+  metric_errors      = "sum:trace.graphql.execute.errors{${local.monitor_dimensions}}.as_rate().rollup(sum,60)"
+  metric_hits        = "sum:trace.graphql.execute.hits{${local.monitor_dimensions}}.as_rate().rollup(sum,60)"
+  metric_latency     = "${var.latency_percentile}:trace.graphql.execute{${local.monitor_dimensions}}"
+}
+
+data "datadog_role" "admin_role" {
+  filter = "Admin"
 }
 
 resource "datadog_monitor" "apm_monitor_error_rate" {
-  name = "${var.service_name_readable} – APM - ${var.resource_name} – Error rate is over ${var.error_rate_target}%"
-  count = var.env == "production" ? 1 : 0
-  type = "metric alert"
+  name    = "${var.service_name} – APM - ${var.resource_name} – Error rate is over ${var.error_rate_target}%"
+  count   = var.env == "production" ? 1 : 0
+  type    = "metric alert"
   message = var.message
-  query = "${var.eval_fn}(${var.interval}):(100 * ${local.metric_errors} / ${local.metric_hits}) > ${var.error_rate_target}"
-  tags = var.tags
-  locked = true
+  query   = "${var.eval_fn}(${var.interval}):(100 * ${local.metric_errors} / ${local.metric_hits}) > ${var.error_rate_target}"
+
+  restricted_roles = [data.datadog_role.admin_role.id]
+  tags             = var.tags
 }
 
 resource "datadog_service_level_objective" "apm_slo_error_rate" {
-  name = "${var.service_name_readable} – APM - ${var.resource_name} – Error rate"
+  name  = "${var.service_name} – APM - ${var.resource_name} – Error rate"
   count = var.env == "production" ? 1 : 0
-  type = "monitor"
+  type  = "monitor"
   monitor_ids = [
     datadog_monitor.apm_monitor_error_rate[0].id
   ]
   thresholds {
     timeframe = "30d"
-    target = var.slo_error_rate_target
+    target    = var.slo_error_rate_target
   }
   thresholds {
     timeframe = "90d"
-    target = var.slo_error_rate_target
+    target    = var.slo_error_rate_target
   }
+
   tags = var.tags
 }
 
 resource "datadog_monitor" "apm_monitor_latency" {
-  name = "${var.service_name_readable} – APM - ${var.resource_name} – Latency (${var.latency_percentile}) is over ${var.latency_target}s"
-  count = var.env == "production" ? 1 : 0
-  type = "metric alert"
-  message = var.message
-  query = "${var.eval_fn}(${var.interval}):${local.metric_latency} > ${var.latency_target}"
-  tags = var.tags
-  locked = true
+  name           = "${var.service_name} – APM - ${var.resource_name} – Latency (${var.latency_percentile}) is over ${var.latency_target}s"
+  count          = var.env == "production" ? 1 : 0
+  type           = "metric alert"
+  message        = var.message
+  query          = "${var.eval_fn}(${var.interval}):${local.metric_latency} > ${var.latency_target}"
   notify_no_data = var.notify_on_missing_data
+
+  restricted_roles = [data.datadog_role.admin_role.id]
+  tags             = var.tags
 }
 
 resource "datadog_service_level_objective" "apm_slo_latency" {
-  name = "${var.service_name_readable} – APM - ${var.resource_name} – Latency"
+  name  = "${var.service_name} – APM - ${var.resource_name} – Latency"
   count = var.env == "production" ? 1 : 0
-  type = "monitor"
+  type  = "monitor"
   monitor_ids = [
     datadog_monitor.apm_monitor_latency[0].id
   ]
   thresholds {
     timeframe = "30d"
-    target = var.slo_latency_target
+    target    = var.slo_latency_target
   }
   thresholds {
     timeframe = "90d"
-    target = var.slo_latency_target
+    target    = var.slo_latency_target
   }
+
   tags = var.tags
 }
 

--- a/terraform-datadog-slo-graphql-endpoint/variables.tf
+++ b/terraform-datadog-slo-graphql-endpoint/variables.tf
@@ -11,7 +11,7 @@ variable "resource_name" {
   type = string
 }
 
-variable "service_name_readable" {
+variable "service_name" {
   type = string
 }
 

--- a/terraform-datadog-sqs/main.tf
+++ b/terraform-datadog-sqs/main.tf
@@ -7,10 +7,8 @@ data "datadog_role" "admin_role" {
 }
 
 resource "datadog_monitor" "sqs_number_of_messages_monitor" {
-  name             = trimspace("${var.service_name_readable} – SQS - Total number of messages ${local.identifierLabel}")
-  count            = var.env == "production" ? 1 : 0
-  restricted_roles = [data.datadog_role.admin_role.id]
-  tags             = var.tags
+  name  = trimspace("${var.service_name} – SQS - Total number of messages ${local.identifierLabel}")
+  count = var.env == "production" ? 1 : 0
 
   type    = "metric alert"
   message = var.message
@@ -19,13 +17,14 @@ resource "datadog_monitor" "sqs_number_of_messages_monitor" {
     warning  = var.queue_messages_warning
     critical = var.queue_messages_critical
   }
+
+  restricted_roles = [data.datadog_role.admin_role.id]
+  tags             = var.tags
 }
 
 resource "datadog_monitor" "sqs_number_of_messages_dead_letter_monitor" {
-  name             = trimspace("${var.service_name_readable} – SQS - Total number of messages in dead letter ${local.identifierLabel}")
-  count            = var.env == "production" ? 1 : 0
-  restricted_roles = [data.datadog_role.admin_role.id]
-  tags             = var.tags
+  name  = trimspace("${var.service_name} – SQS - Total number of messages in dead letter ${local.identifierLabel}")
+  count = var.env == "production" ? 1 : 0
 
   type    = "metric alert"
   message = var.message_slack
@@ -34,13 +33,14 @@ resource "datadog_monitor" "sqs_number_of_messages_dead_letter_monitor" {
     critical = var.dead_letter_queue_messages_critical
   }
   renotify_interval = var.dead_letter_queue_renotify_interval
+
+  restricted_roles = [data.datadog_role.admin_role.id]
+  tags             = var.tags
 }
 
 resource "datadog_monitor" "sqs_increased_number_of_messages_dead_letter_monitor" {
-  name             = trimspace("${var.service_name_readable} – SQS - Increased number of messages in dead letter ${local.identifierLabel}")
-  count            = var.env == "production" ? 1 : 0
-  restricted_roles = [data.datadog_role.admin_role.id]
-  tags             = var.tags
+  name  = trimspace("${var.service_name} – SQS - Increased number of messages in dead letter ${local.identifierLabel}")
+  count = var.env == "production" ? 1 : 0
 
   type    = "metric alert"
   message = var.message_opsgenie
@@ -50,4 +50,7 @@ resource "datadog_monitor" "sqs_increased_number_of_messages_dead_letter_monitor
     critical = var.dead_letter_queue_increased_messages_critical
   }
   renotify_interval = var.dead_letter_queue_increased_renotify_interval
+
+  restricted_roles = [data.datadog_role.admin_role.id]
+  tags             = var.tags
 }

--- a/terraform-datadog-sqs/variables.tf
+++ b/terraform-datadog-sqs/variables.tf
@@ -3,7 +3,7 @@ variable "env" {
   type = string
 }
 
-variable "service_name_readable" {
+variable "service_name" {
   type = string
 }
 
@@ -16,56 +16,56 @@ variable "dead_letter_queue_name" {
 }
 
 variable "tags" {
-  type = list(string)
+  type    = list(string)
   default = []
 }
 
 variable "identifier" {
-  type = string
+  type    = string
   default = ""
 }
 
 variable "message_slack" {
-  type = string
+  type    = string
   default = "@slack-figure-alerts"
 }
 
 variable "message_opsgenie" {
-  type = string
+  type    = string
   default = "{{#is_alert}}@opsgenie{{/is_alert}} {{#is_recovery}}@opsgenie{{/is_recovery}}"
 }
 
 variable "message" {
-  type = string
+  type    = string
   default = "@slack-figure-alerts {{#is_alert}}@opsgenie{{/is_alert}} {{#is_recovery}}@opsgenie{{/is_recovery}}"
 }
 
 variable "queue_messages_warning" {
-  type = number
+  type    = number
   default = 25
 }
 
 variable "queue_messages_critical" {
-  type = number
+  type    = number
   default = 100
 }
 
 variable "dead_letter_queue_messages_critical" {
-  type = number
+  type    = number
   default = 50
 }
 
 variable "dead_letter_queue_renotify_interval" {
-  type = number
+  type    = number
   default = 24 * 60
 }
 
 variable "dead_letter_queue_increased_messages_critical" {
-  type = number
+  type    = number
   default = 20
 }
 
 variable "dead_letter_queue_increased_renotify_interval" {
-  type = number
+  type    = number
   default = 24 * 60
 }

--- a/terraform-ecs-fargate-autoscaling-basic/autoscaling.tf
+++ b/terraform-ecs-fargate-autoscaling-basic/autoscaling.tf
@@ -4,11 +4,11 @@ locals {
 }
 
 resource "aws_appautoscaling_target" "target" {
-  service_namespace = "ecs"
-  resource_id = local.resource_id
+  service_namespace  = "ecs"
+  resource_id        = local.resource_id
   scalable_dimension = "ecs:service:DesiredCount"
-  min_capacity = var.min_capacity
-  max_capacity = var.max_capacity
+  min_capacity       = var.min_capacity
+  max_capacity       = var.max_capacity
 
   lifecycle {
     # see https://github.com/hashicorp/terraform-provider-aws/issues/31261
@@ -20,19 +20,19 @@ resource "aws_appautoscaling_target" "target" {
 }
 
 resource "aws_appautoscaling_policy" "up" {
-  name = "${var.name_prefix}_ECS_ScaleUp"
-  service_namespace = "ecs"
-  resource_id = local.resource_id
+  name               = "${var.name_prefix}_ECS_ScaleUp"
+  service_namespace  = "ecs"
+  resource_id        = local.resource_id
   scalable_dimension = "ecs:service:DesiredCount"
 
   step_scaling_policy_configuration {
-    adjustment_type = "ChangeInCapacity"
-    cooldown = 60
+    adjustment_type         = "ChangeInCapacity"
+    cooldown                = 60
     metric_aggregation_type = var.metric_aggregation_type
 
     step_adjustment {
       metric_interval_lower_bound = 0
-      scaling_adjustment = 1
+      scaling_adjustment          = 1
     }
   }
 
@@ -40,19 +40,19 @@ resource "aws_appautoscaling_policy" "up" {
 }
 
 resource "aws_appautoscaling_policy" "down" {
-  name = "${var.name_prefix}_ECS_ScaleDown"
-  service_namespace = "ecs"
-  resource_id = local.resource_id
+  name               = "${var.name_prefix}_ECS_ScaleDown"
+  service_namespace  = "ecs"
+  resource_id        = local.resource_id
   scalable_dimension = "ecs:service:DesiredCount"
 
   step_scaling_policy_configuration {
-    adjustment_type = "ChangeInCapacity"
-    cooldown = 60
+    adjustment_type         = "ChangeInCapacity"
+    cooldown                = 60
     metric_aggregation_type = var.metric_aggregation_type
 
     step_adjustment {
       metric_interval_upper_bound = 0
-      scaling_adjustment = -1
+      scaling_adjustment          = -1
     }
   }
 
@@ -60,14 +60,14 @@ resource "aws_appautoscaling_policy" "down" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "service_cpu_high" {
-  alarm_name = "${var.name_prefix}_CPUUtilizationHigh"
+  alarm_name          = "${var.name_prefix}_CPUUtilizationHigh"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods = "2"
-  metric_name = "CPUUtilization"
-  namespace = "AWS/ECS"
-  period = "60"
-  statistic = "Average"
-  threshold = var.high_cpu_threshold
+  evaluation_periods  = "2"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = var.high_cpu_threshold
 
   dimensions = {
     ClusterName = var.ecs_cluster_name
@@ -78,14 +78,14 @@ resource "aws_cloudwatch_metric_alarm" "service_cpu_high" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "service_cpu_low" {
-  alarm_name = "${var.name_prefix}_CPUUtilizationLow"
+  alarm_name          = "${var.name_prefix}_CPUUtilizationLow"
   comparison_operator = "LessThanOrEqualToThreshold"
-  evaluation_periods = "2"
-  metric_name = "CPUUtilization"
-  namespace = "AWS/ECS"
-  period = "60"
-  statistic = "Average"
-  threshold = var.low_cpu_threshold
+  evaluation_periods  = "2"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = var.low_cpu_threshold
 
   dimensions = {
     ClusterName = var.ecs_cluster_name

--- a/terraform-ecs-fargate-autoscaling-basic/variables.tf
+++ b/terraform-ecs-fargate-autoscaling-basic/variables.tf
@@ -1,26 +1,26 @@
 
 variable "name_prefix" {
-    type = string
+  type = string
 }
 variable "ecs_cluster_name" {
-    type = string
+  type = string
 }
 variable "ecs_service_name" {
-    type = string
+  type = string
 }
 variable "low_cpu_threshold" {
-    type = number
+  type = number
 }
 variable "high_cpu_threshold" {
-    type = number
+  type = number
 }
 variable "min_capacity" {
-    type = number
+  type = number
 }
 variable "max_capacity" {
-    type = number
+  type = number
 }
 variable "metric_aggregation_type" {
-  type = string
+  type    = string
   default = "Average"
 }

--- a/terraform-ecs-fargate-service/service.tf
+++ b/terraform-ecs-fargate-service/service.tf
@@ -1,26 +1,26 @@
 
 resource "aws_ecs_task_definition" "task_definition_api" {
-  family = var.service_name
-  execution_role_arn = var.task_execution_role_arn
-  task_role_arn = var.task_role_arn
+  family                   = var.service_name
+  execution_role_arn       = var.task_execution_role_arn
+  task_role_arn            = var.task_role_arn
   requires_compatibilities = ["FARGATE"]
-  network_mode = "awsvpc"
-  cpu = 256
-  memory = 512
+  network_mode             = "awsvpc"
+  cpu                      = 256
+  memory                   = 512
   container_definitions = jsonencode([
     {
-      "name": var.service_name,
-      "image": "${var.ecr_repository_url}:latest",
-      "portMappings": [
-            {
-                "containerPort": 4000
-            }
-        ],
-        "readonlyRootFilesystem": true,
+      "name" : var.service_name,
+      "image" : "${var.ecr_repository_url}:latest",
+      "portMappings" : [
+        {
+          "containerPort" : 4000
+        }
+      ],
+      "readonlyRootFilesystem" : true,
     },
     { #checkov:skip=CKV_AWS_336: Ensure ECS containers are limited to read-only access to root filesystems - not possible for datadog-agent
-      "name": "datadog-agent",
-      "image": "datadog/agent:latest"
+      "name" : "datadog-agent",
+      "image" : "datadog/agent:latest"
     }
   ])
 
@@ -30,24 +30,24 @@ resource "aws_ecs_task_definition" "task_definition_api" {
 }
 
 resource "aws_ecs_service" "ecs_service" {
-  name = var.service_name
-  cluster = var.ecs_cluster_id
-  launch_type = "FARGATE"
+  name            = var.service_name
+  cluster         = var.ecs_cluster_id
+  launch_type     = "FARGATE"
   task_definition = aws_ecs_task_definition.task_definition_api.arn
-  propagate_tags = "SERVICE"
+  propagate_tags  = "SERVICE"
 
-  desired_count = var.desired_count
+  desired_count                     = var.desired_count
   health_check_grace_period_seconds = 30
 
   network_configuration {
-    subnets = var.subnet_ids
+    subnets         = var.subnet_ids
     security_groups = var.security_group_ids
   }
 
   load_balancer {
     target_group_arn = aws_alb_target_group.ecs_service_target_group.arn
-    container_name = var.service_name
-    container_port = var.service_port
+    container_name   = var.service_name
+    container_port   = var.service_port
   }
 
   lifecycle {
@@ -59,22 +59,22 @@ resource "aws_ecs_service" "ecs_service" {
 }
 
 resource "aws_alb_target_group" "ecs_service_target_group" {
-  name = substr(var.service_name, 0, 32)
-  port = 80
-  protocol = "HTTP"
-  vpc_id = var.vpc_id
-  target_type = "ip"
+  name                 = substr(var.service_name, 0, 32)
+  port                 = 80
+  protocol             = "HTTP"
+  vpc_id               = var.vpc_id
+  target_type          = "ip"
   deregistration_delay = 30
 
   health_check {
-    healthy_threshold = var.load_balancer_health_check_healthy_threshold
+    healthy_threshold   = var.load_balancer_health_check_healthy_threshold
     unhealthy_threshold = var.load_balancer_health_check_unhealthy_threshold
-    interval = 30
-    matcher = 200
-    path = var.load_balancer_health_check_path
-    port = "traffic-port"
-    protocol = "HTTP"
-    timeout = 5
+    interval            = 30
+    matcher             = 200
+    path                = var.load_balancer_health_check_path
+    port                = "traffic-port"
+    protocol            = "HTTP"
+    timeout             = 5
   }
 }
 
@@ -82,7 +82,7 @@ resource "aws_alb_listener_rule" "ecs_alb_listener_rule" {
   listener_arn = var.load_balancer_listener_arn
 
   action {
-    type = "forward"
+    type             = "forward"
     target_group_arn = aws_alb_target_group.ecs_service_target_group.arn
   }
 

--- a/terraform-ecs-fargate-service/variables.tf
+++ b/terraform-ecs-fargate-service/variables.tf
@@ -1,58 +1,58 @@
 
 variable "env" {
-    type = string
+  type = string
 }
 variable "ecs_cluster_id" {
-    type = string
+  type = string
 }
 variable "vpc_id" {
-    type = string
+  type = string
 }
 variable "service_port" {
-    type = number
+  type = number
 }
 variable "service_name" {
-    type = string
+  type = string
 }
 variable "task_execution_role_arn" {
-    type = string
+  type = string
 }
 variable "task_role_arn" {
-    type = string
+  type = string
 }
 variable "load_balancer_listener_arn" {
-    type = string
+  type = string
 }
 variable "load_balancer_listener_rule_host_headers" {
-    type = list(string)
+  type = list(string)
 }
 variable "load_balancer_listener_rule_path_patterns" {
-    type = list(string)
+  type = list(string)
 }
 variable "load_balancer_health_check_path" {
-    type = string
+  type = string
 }
 
 variable "load_balancer_health_check_healthy_threshold" {
-    type = number
-    default = 5
+  type    = number
+  default = 5
 }
 
 variable "load_balancer_health_check_unhealthy_threshold" {
-    type = number
-    default = 2
+  type    = number
+  default = 2
 }
 
 variable "ecr_repository_url" {
-    type = string
+  type = string
 }
 variable "desired_count" {
-    type = number
-    default = 1 
+  type    = number
+  default = 1
 }
-variable "subnet_ids" { 
-    type = list(string) 
+variable "subnet_ids" {
+  type = list(string)
 }
-variable "security_group_ids" { 
-    type = list(string) 
+variable "security_group_ids" {
+  type = list(string)
 }


### PR DESCRIPTION
Jediný dvě změny je nahrazení deprekované `locked` property za `restricted_roles` a odstranění "readable" service names. Zbytek změn jsou jen whitespaces po aplikaci `terraform format`.

Začal jsem to upravovat, protože chci upravit ty čtyři moduly na SLOčka (ty `terraform-datadog-slo-*` se dají přepsat aby reusovaly `terraform-datadog-metric-slo` a neduplikovaly kód), ale pošlu to až jako další PR.