### PR TITLE
fix: return readable resource name in express monitor FGR3-2585

### DIFF
--- a/terraform-datadog-monitor-express-endpoint/main.tf
+++ b/terraform-datadog-monitor-express-endpoint/main.tf
@@ -14,7 +14,7 @@ data "datadog_role" "admin_role" {
 resource "datadog_monitor" "apm_monitor_error_rate" {
   count = local.count
 
-  name    = "${var.service_name} – APM - ${var.resource_name} – Error rate"
+  name    = "${var.service_name} – APM - ${var.resource_name_readable} – Error rate"
   type    = "metric alert"
   message = var.message
   query   = "${var.eval_fn}(${var.interval}):(100 * ${local.metric_errors} / ${local.metric_hits}) > ${var.error_rate_target}"
@@ -26,7 +26,7 @@ resource "datadog_monitor" "apm_monitor_error_rate" {
 resource "datadog_monitor" "apm_monitor_latency" {
   count = local.count
 
-  name           = "${var.service_name} – APM - ${var.resource_name} – Latency"
+  name           = "${var.service_name} – APM - ${var.resource_name_readable} – Latency"
   type           = "metric alert"
   message        = var.message
   query          = "${var.eval_fn}(${var.interval}):${local.metric_latency} > ${var.latency_target}"

--- a/terraform-datadog-monitor-express-endpoint/variables.tf
+++ b/terraform-datadog-monitor-express-endpoint/variables.tf
@@ -7,6 +7,9 @@ variable "resource_name" {
   type = string
 }
 
+variable "resource_name_readable" {
+  type = string
+}
 variable "service_name" {
   type = string
 }


### PR DESCRIPTION
Jsem se moc nechal unést při tom [odstraňování readable service names](https://github.com/FigurePOS/terraform-modules/pull/12/files). Resource name by mohl zůstat v readable verzi:
![CleanShot 2023-10-04 at 17 58 43](https://github.com/FigurePOS/terraform-modules/assets/215660/a9e9c863-71f6-40cf-bffb-76529fe1afee)
