### PR TITLE
fix(task): entry point + simplify input variables  FGR3-2215

### DIFF
--- a/terraform-ecs-fargate-autoscaling-basic/variables.tf
+++ b/terraform-ecs-fargate-autoscaling-basic/variables.tf
@@ -3,7 +3,8 @@ variable "name_prefix" {
   type = string
 }
 variable "ecs_cluster_name" {
-  type = string
+  type    = string
+  default = "fgr-ecs-cluster"
 }
 variable "ecs_service_name" {
   type = string

--- a/terraform-ecs-fargate-service/data.tf
+++ b/terraform-ecs-fargate-service/data.tf
@@ -1,0 +1,37 @@
+data "aws_ecs_cluster" "main" {
+  cluster_name = var.ecs_cluster_name
+}
+
+data "aws_lb" "main" {
+  name = var.lb_name
+}
+
+data "aws_lb_listener" "https" {
+  load_balancer_arn = data.aws_lb.main.arn
+  port              = 443
+}
+
+data "aws_security_group" "cluster" {
+  filter {
+    name   = "tag:Purpose"
+    values = ["cluster"]
+  }
+}
+
+data "aws_subnets" "private" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.main.id]
+  }
+  filter {
+    name   = "tag:Network"
+    values = ["fgr-private-services"]
+  }
+}
+
+data "aws_vpc" "main" {
+  filter {
+    name   = "tag:Purpose"
+    values = ["main"]
+  }
+}

--- a/terraform-ecs-fargate-service/service.tf
+++ b/terraform-ecs-fargate-service/service.tf
@@ -29,11 +29,7 @@ resource "aws_ecs_task_definition" "service" {
           "awslogs-stream-prefix" : "${var.service_name}"
         }
       },
-      "entryPoint" : [
-        "sh",
-        "-c",
-        "exec node --enable-source-maps ${var.entry_point}"
-      ],
+      "entryPoint" : local.entry_point,
       "dockerLabels" : {
         "com.datadoghq.tags.env" : "${var.env}",
         "com.datadoghq.tags.service" : "${var.service_name}",

--- a/terraform-ecs-fargate-service/service.tf
+++ b/terraform-ecs-fargate-service/service.tf
@@ -161,7 +161,7 @@ resource "aws_ecs_task_definition" "service" {
 
 resource "aws_ecs_service" "service" {
   name            = var.service_name
-  cluster         = var.ecs_cluster_id
+  cluster         = data.aws_ecs_cluster.main.id
   launch_type     = "FARGATE"
   task_definition = aws_ecs_task_definition.service.arn
   propagate_tags  = "SERVICE"
@@ -175,8 +175,8 @@ resource "aws_ecs_service" "service" {
   }
 
   network_configuration {
-    subnets         = var.subnet_ids
-    security_groups = var.security_group_ids
+    subnets         = data.aws_subnets.private.ids
+    security_groups = [data.aws_security_group.cluster.id]
   }
 
   load_balancer {
@@ -190,7 +190,7 @@ resource "aws_alb_target_group" "service" {
   name                 = substr(var.service_name, 0, 32)
   port                 = 80
   protocol             = "HTTP"
-  vpc_id               = var.vpc_id
+  vpc_id               = data.aws_vpc.main.id
   target_type          = "ip"
   deregistration_delay = 30
 
@@ -204,15 +204,6 @@ resource "aws_alb_target_group" "service" {
     protocol            = "HTTP"
     timeout             = 5
   }
-}
-
-data "aws_lb" "main" {
-  name = "fgr-ecs-load-balancer"
-}
-
-data "aws_lb_listener" "https" {
-  load_balancer_arn = data.aws_lb.main.arn
-  port              = 443
 }
 
 resource "aws_alb_listener_rule" "service" {

--- a/terraform-ecs-fargate-service/variables.tf
+++ b/terraform-ecs-fargate-service/variables.tf
@@ -22,7 +22,12 @@ variable "ecs_cluster_id" {
 
 variable "entry_point" {
   type    = string
-  default = "build/index.js"
+  default = ""
+}
+
+variable "entry_point_node_script" {
+  type    = string
+  default = ""
 }
 
 variable "env" {
@@ -119,4 +124,5 @@ variable "vpc_id" {
 
 locals {
   lb_listener_rule_host_header = var.lb_listener_rule_host_header[var.env]
+  entry_point                  = var.entry_point != "" ? ["sh", "-c", var.entry_point] : (var.entry_point_node_script != "" ? ["sh", "-c", "exec node --enable-source-maps ${var.entry_point_node_script}"] : [])
 }

--- a/terraform-ecs-fargate-service/variables.tf
+++ b/terraform-ecs-fargate-service/variables.tf
@@ -16,8 +16,9 @@ variable "ecr_repository_url" {
   type = string
 }
 
-variable "ecs_cluster_id" {
+variable "ecs_cluster_name" {
   type = string
+  default = "fgr-ecs-cluster"
 }
 
 variable "entry_point" {
@@ -68,8 +69,9 @@ variable "lb_listener_rule_path_pattern" {
   type = list(string)
 }
 
-variable "security_group_ids" {
-  type = list(string)
+variable "lb_name" {
+  type = string
+  default = "fgr-ecs-load-balancer"
 }
 
 variable "service_custom_definition" {
@@ -96,10 +98,6 @@ variable "service_secrets" {
   default = []
 }
 
-variable "subnet_ids" {
-  type = list(string)
-}
-
 variable "task_cpu" {
   type    = number
   default = 256
@@ -114,10 +112,6 @@ variable "task_execution_role_arn" {
   type = string
 }
 variable "task_role_arn" {
-  type = string
-}
-
-variable "vpc_id" {
   type = string
 }
 


### PR DESCRIPTION
Hlavně kvůli Javě musím trochu změnit definici entry pointu. Když bude zadaná var `entry_point`, tak se použije, když ne a bude zadaná `entry_point_node_script`, tak se před ni přidá `exec node --enable-source-maps` a pokud nebude zadaná ani jedna, tak zůstane entry point prázdný. 