### PR TITLE
fix: remove path_prefix env var from ecs task + add tags FGR3-2215

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  node-ecs: figure/node-ecs@2.5.0
+  node-ecs: figure/node-ecs@3.0.0
 
 workflows:
   terraform:

--- a/terraform-ecs-fargate-service/service.tf
+++ b/terraform-ecs-fargate-service/service.tf
@@ -83,10 +83,6 @@ resource "aws_ecs_task_definition" "service" {
           "value" : "${var.env}"
         },
         {
-          "name" : "PATH_PREFIX",
-          "value" : "/${var.service_name}"
-        },
-        {
           "name" : "PORT",
           "value" : "${var.service_port}"
         },
@@ -157,6 +153,11 @@ resource "aws_ecs_task_definition" "service" {
       "volumesFrom" : [],
     }
   ])
+
+  tags = {
+    "Environment" = var.env
+    "Service"     = var.service_name
+  }
 }
 
 resource "aws_ecs_service" "service" {
@@ -184,6 +185,11 @@ resource "aws_ecs_service" "service" {
     container_name   = var.service_name
     container_port   = var.service_port
   }
+
+  tags = {
+    "Environment" = var.env
+    "Service"     = var.service_name
+  }
 }
 
 resource "aws_alb_target_group" "service" {
@@ -203,6 +209,11 @@ resource "aws_alb_target_group" "service" {
     port                = "traffic-port"
     protocol            = "HTTP"
     timeout             = 5
+  }
+
+  tags = {
+    "Environment" = var.env
+    "Service"     = var.service_name
   }
 }
 
@@ -230,5 +241,10 @@ resource "aws_alb_listener_rule" "service" {
     ignore_changes = [
       priority
     ]
+  }
+
+  tags = {
+    "Environment" = var.env
+    "Service"     = var.service_name
   }
 }


### PR DESCRIPTION
Do tý `PATH_PREFIX` env proměnný se nedává service name ale např. `/message-router` (a možná ani nebude potřeba všude), tak bych to raději nastavoval per service. 

A k tomu jsem přidal tagy. Nastavují se sice v každý servise přes default tagy (např. https://github.com/FigurePOS/fgr-message-router/blob/dc8922d717032eb61fb317a2fb671d7c83d6b4e9/tf/general.tf#L25-L30), ale když to tam nedám, tak to v plánu dělá takovejhle zbytečnej bordel (zřejmě bug toho aws modulu):
![CleanShot 2024-02-14 at 13 03 27@2x](https://github.com/FigurePOS/terraform-modules/assets/215660/46a240e3-4cc1-44df-94c9-d42727a7a0ae)
