### PR TITLE
feat: add iam roles to ecs-task module FGR3-2215

### DIFF
--- a/terraform-ecs-fargate-service/execution_role.tf
+++ b/terraform-ecs-fargate-service/execution_role.tf
@@ -1,0 +1,77 @@
+
+resource "aws_iam_role" "ecs_task_execution_role" {
+  name               = "${var.service_name}__ecs_task_execution"
+  path               = "/"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_execution_role_assume_policy.json
+}
+
+data "aws_iam_policy_document" "ecs_task_execution_role_assume_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_service" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_default" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = aws_iam_policy.ecs_task_execution_role_default.arn
+}
+
+resource "aws_iam_policy" "ecs_task_execution_role_default" {
+  name   = "${var.service_name}__ecs_execution_default"
+  policy = data.aws_iam_policy_document.ecs_task_execution_role_default.json
+}
+
+data "aws_iam_policy_document" "ecs_task_execution_role_default" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+    ]
+    resources = [
+      "arn:aws:kms:${var.aws_region}:${var.aws_account_id}:alias/aws/ssm",
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "ssm:GetParameters",
+      "ssm:DescribeParameters",
+    ]
+    resources = [
+      "arn:aws:ssm:${var.aws_region}:${var.aws_account_id}:parameter/*",
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "logs:*",
+    ]
+    resources = [
+      "arn:aws:logs:${var.aws_region}:${var.aws_account_id}:*",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_custom" {
+  count      = var.task_execution_policy != null ? 1 : 0
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = aws_iam_policy.ecs_task_execution_role_custom[0].arn
+}
+
+resource "aws_iam_policy" "ecs_task_execution_role_custom" {
+  count      = var.task_execution_policy != null ? 1 : 0
+  name   = "${var.service_name}__ecs_execution_custom"
+  policy = var.task_execution_policy.json
+}

--- a/terraform-ecs-fargate-service/task_role.tf
+++ b/terraform-ecs-fargate-service/task_role.tf
@@ -1,0 +1,68 @@
+
+resource "aws_iam_role" "ecs_task_role" {
+  name               = "${var.service_name}__ecs_task"
+  path               = "/"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_role_assume_policy.json
+}
+
+data "aws_iam_policy_document" "ecs_task_role_assume_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_role_default" {
+  role       = aws_iam_role.ecs_task_role.name
+  policy_arn = aws_iam_policy.ecs_task_role_default.arn
+}
+
+resource "aws_iam_policy" "ecs_task_role_default" {
+  name   = "${var.service_name}__ecs_task_default"
+  policy = data.aws_iam_policy_document.ecs_task_role_default.json
+}
+
+
+data "aws_iam_policy_document" "ecs_task_role_default" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:Encrypt",
+      "kms:Generate*",
+    ]
+    resources = [
+      "arn:aws:kms:${var.aws_region}:${var.aws_account_id}:key/*",
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "ssmmessages:CreateControlChannel",
+      "ssmmessages:CreateDataChannel",
+      "ssmmessages:OpenControlChannel",
+      "ssmmessages:OpenDataChannel",
+    ]
+    resources = [
+      "*",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_role_custom" {
+  count      = var.task_policy != null ? 1 : 0
+  role       = aws_iam_role.ecs_task_role.name
+  policy_arn = aws_iam_policy.ecs_task_role_custom[0].arn
+}
+
+resource "aws_iam_policy" "ecs_task_role_custom" {
+  count  = var.task_policy != null ? 1 : 0
+  name   = "${var.service_name}__ecs_task_custom"
+  policy = var.task_policy.json
+}
+

--- a/terraform-ecs-fargate-service/variables.tf
+++ b/terraform-ecs-fargate-service/variables.tf
@@ -1,3 +1,7 @@
+variable "aws_account_id" {
+  type = string
+}
+
 variable "aws_region" {
   type    = string
   default = "us-east-1"
@@ -17,7 +21,7 @@ variable "ecr_repository_url" {
 }
 
 variable "ecs_cluster_name" {
-  type = string
+  type    = string
   default = "fgr-ecs-cluster"
 }
 
@@ -70,7 +74,7 @@ variable "lb_listener_rule_path_pattern" {
 }
 
 variable "lb_name" {
-  type = string
+  type    = string
   default = "fgr-ecs-load-balancer"
 }
 
@@ -108,11 +112,14 @@ variable "task_memory" {
   default = 512
 }
 
-variable "task_execution_role_arn" {
-  type = string
+variable "task_execution_policy" {
+  type    = any
+  default = null
 }
-variable "task_role_arn" {
-  type = string
+
+variable "task_policy" {
+  type    = any
+  default = null
 }
 
 


### PR DESCRIPTION
Popsal jsem to víc v tomhle PR kde jsem to zkoušel: https://github.com/FigurePOS/node-template/pull/53#issuecomment-1945751222

- Přidal jsem do modulu task roli i execution roli
- Povolil jsem na tasku [volat exec](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html#ecs-exec-enabling-and-using)
- Přidal jsem health check na datadog kontejner