### PR TITLE
feat: add log group to ecs-task module and use unified task permissions FGR3-2215

### DIFF
--- a/terraform-ecs-fargate-service/data.tf
+++ b/terraform-ecs-fargate-service/data.tf
@@ -2,6 +2,14 @@ data "aws_ecs_cluster" "main" {
   cluster_name = var.ecs_cluster_name
 }
 
+data "aws_iam_policy" "ecs_task_execution_default" {
+  name = "ecs_execution_default"
+}
+
+data "aws_iam_policy" "ecs_task_default" {
+  name = "ecs_task_default"
+}
+
 data "aws_lb" "main" {
   name = var.lb_name
 }

--- a/terraform-ecs-fargate-service/ecs_task.tf
+++ b/terraform-ecs-fargate-service/ecs_task.tf
@@ -262,3 +262,8 @@ resource "aws_alb_listener_rule" "service" {
     "Service"     = var.service_name
   }
 }
+
+resource "aws_cloudwatch_log_group" "log_group" {
+  name              = "/figure/container/${var.service_name}"
+  retention_in_days = 365
+}

--- a/terraform-ecs-fargate-service/execution_role.tf
+++ b/terraform-ecs-fargate-service/execution_role.tf
@@ -23,45 +23,7 @@ resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_service" {
 
 resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_default" {
   role       = aws_iam_role.ecs_task_execution_role.name
-  policy_arn = aws_iam_policy.ecs_task_execution_role_default.arn
-}
-
-resource "aws_iam_policy" "ecs_task_execution_role_default" {
-  name   = "${var.service_name}__ecs_execution_default"
-  policy = data.aws_iam_policy_document.ecs_task_execution_role_default.json
-}
-
-data "aws_iam_policy_document" "ecs_task_execution_role_default" {
-  statement {
-    effect = "Allow"
-    actions = [
-      "kms:Decrypt",
-    ]
-    resources = [
-      "arn:aws:kms:${var.aws_region}:${var.aws_account_id}:alias/aws/ssm",
-    ]
-  }
-
-  statement {
-    effect = "Allow"
-    actions = [
-      "ssm:GetParameters",
-      "ssm:DescribeParameters",
-    ]
-    resources = [
-      "arn:aws:ssm:${var.aws_region}:${var.aws_account_id}:parameter/*",
-    ]
-  }
-
-  statement {
-    effect = "Allow"
-    actions = [
-      "logs:*",
-    ]
-    resources = [
-      "arn:aws:logs:${var.aws_region}:${var.aws_account_id}:*",
-    ]
-  }
+  policy_arn = data.aws_iam_policy.ecs_task_execution_default.arn
 }
 
 resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_custom" {

--- a/terraform-ecs-fargate-service/task_role.tf
+++ b/terraform-ecs-fargate-service/task_role.tf
@@ -18,40 +18,7 @@ data "aws_iam_policy_document" "ecs_task_role_assume_policy" {
 
 resource "aws_iam_role_policy_attachment" "ecs_task_role_default" {
   role       = aws_iam_role.ecs_task_role.name
-  policy_arn = aws_iam_policy.ecs_task_role_default.arn
-}
-
-resource "aws_iam_policy" "ecs_task_role_default" {
-  name   = "${var.service_name}__ecs_task_default"
-  policy = data.aws_iam_policy_document.ecs_task_role_default.json
-}
-
-
-data "aws_iam_policy_document" "ecs_task_role_default" {
-  statement {
-    effect = "Allow"
-    actions = [
-      "kms:Decrypt",
-      "kms:Encrypt",
-      "kms:Generate*",
-    ]
-    resources = [
-      "arn:aws:kms:${var.aws_region}:${var.aws_account_id}:key/*",
-    ]
-  }
-
-  statement {
-    effect = "Allow"
-    actions = [
-      "ssmmessages:CreateControlChannel",
-      "ssmmessages:CreateDataChannel",
-      "ssmmessages:OpenControlChannel",
-      "ssmmessages:OpenDataChannel",
-    ]
-    resources = [
-      "*",
-    ]
-  }
+  policy_arn = data.aws_iam_policy.ecs_task_default.arn
 }
 
 resource "aws_iam_role_policy_attachment" "ecs_task_role_custom" {


### PR DESCRIPTION
Tak přece jen ještě jedno doplnění. 🙂 Každý ecs task má log groupu, ta se taky nemusí definovat v každým repu.