### PR TITLE
fix: add empty systemControls to ecs task definition FGR3-3975

### DIFF
--- a/terraform-ecs-fargate-service/ecs.tf
+++ b/terraform-ecs-fargate-service/ecs.tf
@@ -95,6 +95,7 @@ resource "aws_ecs_task_definition" "service" {
       "readonlyRootFilesystem" : true,
       "mountPoints" : [],
       "volumesFrom" : [],
+      "systemControls" : [],
     }, var.service_custom_definition),
     {
       "name" : "datadog-agent",
@@ -161,6 +162,7 @@ resource "aws_ecs_task_definition" "service" {
       "mountPoints" : [],
       "portMappings" : [],
       "volumesFrom" : [],
+      "systemControls" : [],
     }
   ])
 


### PR DESCRIPTION
Tohle ještě zbytečně zavazí v terraform plánu:
![CleanShot 2024-03-06 at 10 38 18](https://github.com/FigurePOS/terraform-modules/assets/215660/f7e50805-f2b0-433c-bbc0-3d48b2f2e313)
