### PR TITLE
feat: output autoscaling policy arns FGR3-4279

### DIFF
--- a/ecs-autoscaling-cpu/outputs.tf
+++ b/ecs-autoscaling-cpu/outputs.tf
@@ -1,0 +1,7 @@
+output "autoscaling_policy_up_arn" {
+  value = aws_appautoscaling_policy.up.arn
+}
+
+output "autoscaling_policy_down_arn" {
+  value = aws_appautoscaling_policy.down.arn
+}


### PR DESCRIPTION
Použiju to v Java backendu, kde na ty policies navěsím CloudWatch alarmy na memory:
https://github.com/FigurePOS/figure-backend/pull/698/files#diff-d2280c42a749f3cd2bf829b9eb66e2a30e0821652c7d1c7564aa5cc0e0827f1c

![CleanShot 2024-04-17 at 14 36 56](https://github.com/FigurePOS/terraform-modules/assets/215660/a7c2bde8-4491-432e-8379-a4b6bcbe80e6)
