### PR TITLE
feat: settings for ECS capacity providers to allow running spot instances FGR3-4880

### DIFF
--- a/ecs-service/ecs.tf
+++ b/ecs-service/ecs.tf
@@ -202,6 +202,24 @@ resource "aws_ecs_service" "service" {
     container_port   = var.service_port
   }
 
+  dynamic "capacity_provider_strategy" {
+    for_each = var.capacity["reserved"]["weight"] > 0 ? [1] : []
+    content {
+      capacity_provider = "FARGATE"
+      base              = var.capacity["reserved"]["base"]
+      weight            = var.capacity["reserved"]["weight"]
+    }
+  }
+
+  dynamic "capacity_provider_strategy" {
+    for_each = var.capacity["spot"]["weight"] > 0 ? [1] : []
+    content {
+      capacity_provider = "FARGATE_SPOT"
+      base              = var.capacity["spot"]["base"]
+      weight            = var.capacity["spot"]["weight"]
+    }
+  }
+
   tags = {
     "Environment" = var.env
     "Service"     = var.service_name

--- a/ecs-service/variables.tf
+++ b/ecs-service/variables.tf
@@ -7,6 +7,20 @@ variable "aws_region" {
   default = "us-east-1"
 }
 
+variable "capacity" {
+  type = map(map(number))
+  default = {
+    reserved = {
+      base   = 1
+      weight = 1
+    }
+    spot  = {
+      base   = 0
+      weight = 0
+    }
+  }
+}
+
 variable "dd_agent_version" {
   type    = string
   default = "latest"


### PR DESCRIPTION
Přišla mi vhodná chvíle ušetřit pár dolarů. 😅 A je to docela rychlá věc, kterou bysme mohli vyzkoušet třeba na jedný servise.

- `base` je počet instancí, který se mají pro danýho capacity providera pustit vždycky - default je `1` pro `reserved` instance.
- `weight` je poměr instancí. Default je `100` reserved a `0` spot.

V produkci např. u Business Config API máme 3-10 tasků. Pokud bychom chtěli být konzervativní, tak můžeme na začátek zkusit třeba 2:1 reserved:spot, tak by to vypadalo takto:
```
{
    reserved = {
      base   = 2
      weight = 2
    }
    spot  = {
      base   = 1
      weight = 1
    }
  }
```

Dev by se vlastně asi na spotech mohl pustit celý. 🤔 🙂 
