### PR TITLE
fix: set force_new_deployment for ecs task FGR3-5031

### DIFF
--- a/ecs-service/ecs.tf
+++ b/ecs-service/ecs.tf
@@ -181,6 +181,7 @@ resource "aws_ecs_service" "service" {
   propagate_tags  = "SERVICE"
 
   enable_execute_command = true
+  force_new_deployment   = true
 
   desired_count                     = var.desired_count
   health_check_grace_period_seconds = var.health_check_grace_period_seconds


### PR DESCRIPTION
Nový deployment chceme stejně vždycky a bez toho se snaží replacovat celou servisu při změně nastavení spotů: 

![CleanShot 2024-09-16 at 15 20 12](https://github.com/user-attachments/assets/fcbaaabb-7d13-48ac-b58b-d66c98e3c379)


![CleanShot 2024-09-16 at 15 20 32](https://github.com/user-attachments/assets/0fbfeca6-8bfc-4883-ab64-ef4f29d7853e)
