### PR TITLE
feat(datadog-sqs): allow optional message for total messages monitor FGR3-5150

### DIFF
--- a/datadog-sqs/datadog_monitor.tf
+++ b/datadog-sqs/datadog_monitor.tf
@@ -15,7 +15,7 @@ resource "datadog_monitor" "sqs_number_of_messages_monitor" {
 
   name    = trimspace("${var.service_name} – SQS - Total number of messages ${local.identifierLabel}")
   type    = "metric alert"
-  message = "{{#is_alert}}${local.oncall_handle} ${local.slack_warning_handle}{{/is_alert}} {{#is_alert_recovery}}${local.oncall_handle} ${local.slack_warning_handle}{{/is_alert_recovery}}"
+  message = "{{#is_alert}}${local.oncall_handle} ${local.slack_warning_handle}{{/is_alert}} {{#is_alert_recovery}}${local.oncall_handle} ${local.slack_warning_handle}{{/is_alert_recovery}} ${var.total_number_message}"
   query   = "avg(last_1h):aws.sqs.approximate_number_of_messages_visible{queuename:${lower(var.queue_name)},env:${var.env}}.rollup(min, ${var.queue_rollup}) > ${var.queue_messages_critical}"
   monitor_thresholds {
     warning  = var.queue_messages_warning

--- a/datadog-sqs/variables.tf
+++ b/datadog-sqs/variables.tf
@@ -25,6 +25,11 @@ variable "identifier" {
   default = ""
 }
 
+variable "total_number_message" {
+  type    = string
+  default = ""
+}
+
 variable "queue_messages_warning" {
   type    = number
   default = 25


### PR DESCRIPTION
paymenty notifikují navíc ještě do `#alerts-payments`, tak přidávám volitelný parametr

![CleanShot 2024-09-18 at 10 21 42](https://github.com/user-attachments/assets/3f2cb5e2-03a1-44d0-a3c4-234ad718299a)
