### PR TITLE
feat: introduce sqs utilization metric to autoscaling FGR3-5364

### DIFF
--- a/aws-ecs-autoscaling/policy.tf
+++ b/aws-ecs-autoscaling/policy.tf
@@ -24,6 +24,8 @@ resource "aws_appautoscaling_policy" "target_tracking" {
 }
 
 resource "aws_appautoscaling_policy" "sqs_backlog_policy" {
+  count = var.sqs_queue_params != null ? 1 : 0
+
   name               = "${var.ecs_service_name}-sqs-backlog-scaling-policy"
   policy_type        = "TargetTrackingScaling"
   resource_id        = aws_appautoscaling_target.this.resource_id
@@ -31,7 +33,7 @@ resource "aws_appautoscaling_policy" "sqs_backlog_policy" {
   service_namespace  = aws_appautoscaling_target.this.service_namespace
 
   target_tracking_scaling_policy_configuration {
-    target_value       = var.sqs_messages_target_value
+    target_value       = var.sqs_queue_params.messages_target_value
     scale_in_cooldown  = var.scale_in_cooldown
     scale_out_cooldown = var.scale_out_cooldown
 
@@ -47,7 +49,7 @@ resource "aws_appautoscaling_policy" "sqs_backlog_policy" {
 
             dimensions {
               name  = "QueueName"
-              value = var.sqs_queue_name
+              value = var.sqs_queue_params.queue_name
             }
           }
 

--- a/aws-ecs-autoscaling/variables.tf
+++ b/aws-ecs-autoscaling/variables.tf
@@ -13,6 +13,17 @@ variable "cpu_target_value" {
   default     = 70
 }
 
+variable "sqs_messages_target_value" {
+  type        = number
+  description = "The target number of messages in the SQS queue for scaling."
+  default     = 100
+}
+
+variable "sqs_queue_name" {
+  type        = string
+  description = "The name of the SQS queue to monitor for scaling."
+}
+
 variable "min_capacity" {
   type = number
 }

--- a/aws-ecs-autoscaling/variables.tf
+++ b/aws-ecs-autoscaling/variables.tf
@@ -13,15 +13,13 @@ variable "cpu_target_value" {
   default     = 70
 }
 
-variable "sqs_messages_target_value" {
-  type        = number
-  description = "The target number of messages in the SQS queue for scaling."
-  default     = 100
-}
-
-variable "sqs_queue_name" {
-  type        = string
-  description = "The name of the SQS queue to monitor for scaling."
+variable "sqs_queue_params" {
+  type = object({
+    queue_name = string
+    messages_target_value = string
+  })
+  description = "SQS queue parameters for scaling."
+  default     = null
 }
 
 variable "min_capacity" {

--- a/aws-ecs-autoscaling/variables.tf
+++ b/aws-ecs-autoscaling/variables.tf
@@ -15,7 +15,7 @@ variable "cpu_target_value" {
 
 variable "sqs_queue_params" {
   type = object({
-    queue_name = string
+    queue_name            = string
     messages_target_value = string
   })
   description = "SQS queue parameters for scaling."


### PR DESCRIPTION
Lokálně na Auth service to vypadá dobře, ale chtělo by to pořádně otestovat, ale vůbec nevím jak. 😅 

Default na ty zprávy jsem jenom střelil, jsem otevřenej nápadům, vůbec netuším, kolik jich tam tak bývá obecně. Další možnost je ten argument udělat bez defaultu a ať si to každej, kdo to používá vymyslí po svým.

Další věc je ještě, že mě nenapadlo, jak to udělat volitelný, aby sis mohl vybrat, jestli to chceš používat na té service nebo ne. Další modul jsem dělat nechtěl a jediný, co mě napadlo je ten default hodit přestřelenej, takže se k němu nikdy nepřiblížíme a rádoby to nebude fungovat.