### PR TITLE
fix(aws-ecs-task-definition): merge envs and secrets FGR3-6200

### DIFF
--- a/aws-ecs-task-definition/ecs.tf
+++ b/aws-ecs-task-definition/ecs.tf
@@ -3,19 +3,8 @@ locals {
     "Environment" = var.env
     "Service"     = var.service_name
   }
-}
 
-module "app_container_definition" {
-  # checkov:skip=CKV_TF_1: "Ensure Terraform module sources use a commit hash"
-  source  = "cloudposse/ecs-container-definition/aws"
-  version = "0.61.1"
-
-  container_name  = var.service_name
-  container_image = "${var.aws_account_id}.dkr.ecr.${var.aws_region}.amazonaws.com/${var.ecr_repository_uri}:${var.deployment_tag}"
-  essential       = true
-  entrypoint      = local.entry_point
-
-  environment = concat([
+  default_environment = [
     {
       name  = "AWS_REGION",
       value = var.aws_region
@@ -68,9 +57,49 @@ module "app_container_definition" {
       name  = "SERVICE_NAME",
       value = var.service_name
     }
-  ], var.service_envs)
+  ]
 
-  secrets = concat([], var.service_secrets)
+  default_secrets = []
+  
+
+  # Convert default environment to a map for easier merging
+  default_env_map = { for item in local.default_environment : item.name => item.value }
+
+  # Convert service_envs to a map (if it's in the expected format)
+  service_env_map = { for item in var.service_envs : item.name => item.value if can(item.name) && can(item.value) }
+
+  # Merge the maps, with service_env_map taking precedence
+  merged_env_map = merge(local.default_env_map, local.service_env_map)
+
+  # Convert back to the list format required by the module
+  container_environment = [for name, value in local.merged_env_map : { name = name, value = value }]
+
+  # Convert default secrets to a map for easier merging
+  default_secrets_map = { for item in local.default_secrets : item.name => item.valueFrom if can(item.name) && can(item.valueFrom) }
+
+  # Convert service_secrets to a map (if it's in the expected format)
+  service_secrets_map = { for item in var.service_secrets : item.name => item.valueFrom if can(item.name) && can(item.valueFrom) }
+
+  # Merge the maps, with service_secrets_map taking precedence
+  merged_secrets_map = merge(local.default_secrets_map, local.service_secrets_map)
+
+  # Convert back to the list format required by the module
+  container_secrets = [for name, valueFrom in local.merged_secrets_map : { name = name, valueFrom = valueFrom }]
+}
+
+module "app_container_definition" {
+  # checkov:skip=CKV_TF_1: "Ensure Terraform module sources use a commit hash"
+  source  = "cloudposse/ecs-container-definition/aws"
+  version = "0.61.1"
+
+  container_name  = var.service_name
+  container_image = "${var.aws_account_id}.dkr.ecr.${var.aws_region}.amazonaws.com/${var.ecr_repository_uri}:${var.deployment_tag}"
+  essential       = true
+  entrypoint      = local.entry_point
+
+  environment = local.container_environment
+
+  secrets = local.container_secrets
 
   port_mappings = [
     {

--- a/aws-ecs-task-definition/variables.tf
+++ b/aws-ecs-task-definition/variables.tf
@@ -48,7 +48,10 @@ variable "readonly_root_filesystem" {
 }
 
 variable "service_envs" {
-  type    = list(any)
+  type = list(object({
+    name  = string
+    value = string
+  }))
   default = []
 }
 
@@ -62,7 +65,10 @@ variable "service_port" {
 }
 
 variable "service_secrets" {
-  type    = list(any)
+  type = list(object({
+    name      = string
+    valueFrom = string
+  }))
   default = []
 }
 


### PR DESCRIPTION
Ach jo, na to jsem zapomněl. 🙂 V Orders (a Business Configu) se přepisuje defaultní env var `SERVICE_NAME` (u worker se do něj doplňuje suffix `_worker`). Původní řešení používalo `merge()`, který dokázal tu původní hodnotu přepsat. Nahradil jsem to s `concat()` který si ale s duplikovanýma hodnotama neporadí. Jenže už nejde použít `merge()` kvůli tomu že se změnil datový typ těch proměnných (už to není mapa, ale list objektů). Tak je to řešení takový kostrbatější. (Ale funguje, vyzkoušel jsem na Orders)