### PR TITLE
feat: allow aws provider v6

### DIFF
--- a/aws-dynamodb-table/main.tf
+++ b/aws-dynamodb-table/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.75, < 7.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/aws-dynamodb-table/main.tf
+++ b/aws-dynamodb-table/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.75"
+      version = ">= 5.75, < 7.0"
     }
   }
 }

--- a/aws-ecs-autoscaling/main.tf
+++ b/aws-ecs-autoscaling/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.75, < 7.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/aws-ecs-autoscaling/main.tf
+++ b/aws-ecs-autoscaling/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.75"
+      version = ">= 5.75, < 7.0"
     }
   }
 }

--- a/aws-ecs-service/main.tf
+++ b/aws-ecs-service/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.75, < 7.0"
+      version = "~> 6.0"
     }
 
     datadog = {

--- a/aws-ecs-service/main.tf
+++ b/aws-ecs-service/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34"
+      version = ">= 5.75, < 7.0"
     }
 
     datadog = {

--- a/aws-ecs-task-definition/main.tf
+++ b/aws-ecs-task-definition/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.75, < 7.0"
+      version = "~> 6.0"
     }
 
     datadog = {

--- a/aws-ecs-task-definition/main.tf
+++ b/aws-ecs-task-definition/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34"
+      version = ">= 5.75, < 7.0"
     }
 
     datadog = {

--- a/aws-lambda-function/main.tf
+++ b/aws-lambda-function/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.75, < 7.0"
+      version = "~> 6.0"
     }
   }
 

--- a/aws-lambda-function/main.tf
+++ b/aws-lambda-function/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.75"
+      version = ">= 5.75, < 7.0"
     }
   }
 

--- a/aws-s3-bucket/main.tf
+++ b/aws-s3-bucket/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.75, < 7.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/aws-s3-bucket/main.tf
+++ b/aws-s3-bucket/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.75"
+      version = ">= 5.75, < 7.0"
     }
   }
 }

--- a/aws-sqs-queue/main.tf
+++ b/aws-sqs-queue/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.75, < 7.0"
+      version = "~> 6.0"
     }
 
     datadog = {

--- a/aws-sqs-queue/main.tf
+++ b/aws-sqs-queue/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.75"
+      version = ">= 5.75, < 7.0"
     }
 
     datadog = {


### PR DESCRIPTION
Vyšel aws provider v6 a zřejmě je safe upgradnout, ale na druhou stranu asi není dobrý dovolat automaticky upgrade na další major verzi.