### PR TITLE
fix: autoscaling output

### DIFF
--- a/aws-ecs-autoscaling/outputs.tf
+++ b/aws-ecs-autoscaling/outputs.tf
@@ -5,5 +5,5 @@ output "cpu_scaling_policy_arn" {
 
 output "memory_scaling_policy_arn" {
   description = "The ARN of the memory target tracking scaling policy"
-  value       = aws_appautoscaling_policy.memory_target_tracking[0].arn
+  value       = var.memory_target_value != null ? aws_appautoscaling_policy.memory_target_tracking[0].arn : null
 }

--- a/aws-lambda-function/locals.tf
+++ b/aws-lambda-function/locals.tf
@@ -30,8 +30,8 @@ locals {
 
   environment_variables = merge(local.datadog_env_vars, var.environment_variables)
 
-  datadog_layer_arn           = "arn:aws:lambda:${data.aws_region.current.name}:464622532012:layer:Datadog-Node22-x:${var.datadog_layer_version}"
-  datadog_extension_layer_arn = "arn:aws:lambda:${data.aws_region.current.name}:464622532012:layer:Datadog-Extension:${var.datadog_extension_layer_version}"
+  datadog_layer_arn           = "arn:aws:lambda:${data.aws_region.current.region}:464622532012:layer:Datadog-Node22-x:${var.datadog_layer_version}"
+  datadog_extension_layer_arn = "arn:aws:lambda:${data.aws_region.current.region}:464622532012:layer:Datadog-Extension:${var.datadog_extension_layer_version}"
 
   scheduling_enabled = var.schedule_expression != ""
 }


### PR DESCRIPTION
Jedna chyba a jedna deprekace:
<img width="2062" height="812" alt="CleanShot 2025-07-14 at 17 02 57@2x" src="https://github.com/user-attachments/assets/9a1f6802-26ea-41e8-9a5d-717acd195d49" />
