### PR TITLE
feat(lambda): allow disable datadog layers

### DIFF
--- a/aws-lambda-function/lambda.tf
+++ b/aws-lambda-function/lambda.tf
@@ -53,7 +53,11 @@ resource "aws_lambda_function" "this" {
   reserved_concurrent_executions = var.reserved_concurrent_executions
 
   publish = true
-  layers  = concat([local.datadog_layer_arn, local.datadog_extension_layer_arn], var.layers)
+  layers = concat(
+    var.datadog_layer_version != 0 ? [local.datadog_layer_arn] : [],
+    var.datadog_extension_layer_version != 0 ? [local.datadog_extension_layer_arn] : [],
+    var.layers
+  )
 
   depends_on = [
     aws_cloudwatch_log_group.lambda,

--- a/aws-lambda-function/variables.tf
+++ b/aws-lambda-function/variables.tf
@@ -1,13 +1,13 @@
 variable "datadog_extension_layer_version" {
   description = "Datadog extension layer version"
-  type        = string
-  default     = "81"
+  type        = number
+  default     = 83
 }
 
 variable "datadog_layer_version" {
   description = "Datadog layer version"
-  type        = string
-  default     = "125"
+  type        = number
+  default     = 127
 }
 
 variable "dd_service_mapping" {


### PR DESCRIPTION
V Business Configu failuje deploy lambda funkce (https://github.com/FigurePOS/fgr-service-business-config/actions/runs/16723046590) na tom, že funkce překračuje limit 262 MB. Přitom zip má 14 MB, po rozbalení nějakých 95 MB. A ta Datadog Node layer má údajně 5 MB a Datadog Extension 25 MB. 

Ale když tu extension layer odstraním, tak deployment projde a funkce má celkem 82 MB. Když ji tam vrátím, tak zase vyfailuje a tvrdí že celkem to má přes 290 MB. Takže ta extension layer buď má přes 200 MB nebo je tam jiný problém. Napsal jsem jim na support, ale potřebuju tu layer mít možnost vypnout abych aspoň fixnul deploy Business Configu.