### PR TITLE
fix(sqs): enable CloudWatch alarms by default for SQS queues FGR3-7529

### DIFF
--- a/aws-sqs-queue/variables.tf
+++ b/aws-sqs-queue/variables.tf
@@ -54,7 +54,7 @@ variable "dlq_name" {
 variable "enable_cloudwatch_alarms" {
   type        = bool
   description = "Whether to enable CloudWatch alarms for the SQS queues."
-  default     = false
+  default     = true
 }
 
 variable "env" {


### PR DESCRIPTION
On second thought, nechal bych to defaultně zapnutý.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - CloudWatch alarms for SQS queues are now enabled by default, providing immediate monitoring and alerting without additional configuration.
  - Existing environments may see alarms created or updated on next deployment/apply.
  - You can opt out by overriding the default setting if alarms are not desired.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->