### PR TITLE
fix(datadog): support ANY method in http endpoint on dashboard

### DIFF
--- a/datadog-dashboard-service/datadog.tf
+++ b/datadog-dashboard-service/datadog.tf
@@ -2,8 +2,8 @@ locals {
   # Transform http_endpoints from {method, route} to {title, endpoint}
   http_endpoints = [
     for e in var.http_endpoints : {
-      title    = "${upper(e.method)} /${var.api_path_prefix}${e.route}"
-      endpoint = "${lower(e.method)}_/${var.api_path_prefix}${e.route}"
+      title    = "${upper(e.method) == "ANY" ? "*" : upper(e.method)} /${var.api_path_prefix}${e.route}"
+      endpoint = "${upper(e.method) == "ANY" ? "*" : lower(e.method)}_/${var.api_path_prefix}${e.route}"
     }
   ]
 }


### PR DESCRIPTION
Tohle úplně nefunguje. 🙂 
https://github.com/FigurePOS/fgr-service-3rd-party-aggregators/blob/779a13db03c98b2e9fe7f72d1b532724686837d9/tf/datadog.tf#L33

<img width="1280" height="920" alt="CleanShot 2026-03-16 at 09 45 38" src="https://github.com/user-attachments/assets/b9365c95-49c0-4c00-832f-7d2e4da01520" />
