### PR TITLE
fix: send ecs & sqs alarms also on Dev

### DIFF
--- a/aws-ecs-service/cloudwatch_alarms.tf
+++ b/aws-ecs-service/cloudwatch_alarms.tf
@@ -1,12 +1,12 @@
-# CloudWatch alarms for ECS service CPU and memory (production only).
-# Warning thresholds notify Slack only; critical thresholds also page on-call via Rootly.
+# CloudWatch alarms for ECS service CPU and memory.
+# Warning thresholds notify Slack only; critical thresholds also page on-call via Rootly in production.
 
 locals {
-  alarm_name_prefix         = "${var.service_name} ECS"
-  cloudwatch_alarms_enabled = var.env == "production" ? 1 : 0
+  alarm_name_prefix = "${var.service_name} ECS"
+  rootly_enabled    = var.env == "production"
 
-  alerts_slack_sns_topic_arns  = local.cloudwatch_alarms_enabled == 1 ? ["arn:aws:sns:us-east-1:637192944017:alerts-to-slack"] : []
-  alerts_rootly_sns_topic_arns = data.aws_sns_topic.rootly_oncall[*].arn
+  alerts_slack_sns_topic_arns  = ["arn:aws:sns:us-east-1:637192944017:alerts-to-slack"]
+  alerts_rootly_sns_topic_arns = local.rootly_enabled ? data.aws_sns_topic.rootly_oncall[*].arn : []
 
   utilization_alarm_tags = {
     Service = var.service_name
@@ -14,8 +14,6 @@ locals {
 }
 
 resource "aws_cloudwatch_metric_alarm" "ecs_cpu_warning" {
-  count = local.cloudwatch_alarms_enabled
-
   alarm_name        = "${local.alarm_name_prefix} - CPU Utilization Warning"
   alarm_description = "ECS service ${var.service_name} average CPU utilization exceeded warning threshold (${var.cpu_utilization_alarm_warning_threshold}%)."
 
@@ -43,8 +41,6 @@ resource "aws_cloudwatch_metric_alarm" "ecs_cpu_warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "ecs_cpu_critical" {
-  count = local.cloudwatch_alarms_enabled
-
   alarm_name        = "${local.alarm_name_prefix} - CPU Utilization Critical"
   alarm_description = "ECS service ${var.service_name} average CPU utilization exceeded critical threshold (${var.cpu_utilization_alarm_critical_threshold}%)."
 
@@ -72,8 +68,6 @@ resource "aws_cloudwatch_metric_alarm" "ecs_cpu_critical" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "ecs_memory_warning" {
-  count = local.cloudwatch_alarms_enabled
-
   alarm_name        = "${local.alarm_name_prefix} - Memory Utilization Warning"
   alarm_description = "ECS service ${var.service_name} average memory utilization exceeded warning threshold (${var.memory_utilization_alarm_warning_threshold}%)."
 
@@ -101,8 +95,6 @@ resource "aws_cloudwatch_metric_alarm" "ecs_memory_warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "ecs_memory_critical" {
-  count = local.cloudwatch_alarms_enabled
-
   alarm_name        = "${local.alarm_name_prefix} - Memory Utilization Critical"
   alarm_description = "ECS service ${var.service_name} average memory utilization exceeded critical threshold (${var.memory_utilization_alarm_critical_threshold}%)."
 

--- a/aws-ecs-service/data.tf
+++ b/aws-ecs-service/data.tf
@@ -41,6 +41,7 @@ data "aws_vpc" "main" {
 }
 
 data "aws_sns_topic" "rootly_oncall" {
-  count = local.cloudwatch_alarms_enabled
+  count = local.rootly_enabled ? 1 : 0
+  
   name  = "alerts-to-rootly"
 }

--- a/aws-sqs-queue/cloudwatch_alarms.tf
+++ b/aws-sqs-queue/cloudwatch_alarms.tf
@@ -3,8 +3,6 @@
 
 # CloudWatch alarm for dead letter queue message count (warning)
 resource "aws_cloudwatch_metric_alarm" "dlq_messages_count_warning" {
-  count = local.cloudwatch_alarms_enabled
-
   alarm_name        = "${local.alarm_name_prefix} - DLQ Messages Count Warning"
   alarm_description = "SQS dead letter queue ${aws_sqs_queue.dlq.name} has messages (> ${var.dlq_messages_count_threshold})."
 
@@ -33,8 +31,6 @@ resource "aws_cloudwatch_metric_alarm" "dlq_messages_count_warning" {
 # CloudWatch alarm for increasing dead letter queue messages (critical)
 # Uses metric math to detect rate of increase; RATE() requires >= 2 evaluation periods.
 resource "aws_cloudwatch_metric_alarm" "dlq_messages_increasing_critical" {
-  count = local.cloudwatch_alarms_enabled
-
   alarm_name        = "${local.alarm_name_prefix} - DLQ Messages Increasing Critical"
   alarm_description = "SQS dead letter queue ${aws_sqs_queue.dlq.name} messages are increasing (rate > ${var.dlq_messages_increase_threshold}/s)."
 
@@ -76,8 +72,6 @@ resource "aws_cloudwatch_metric_alarm" "dlq_messages_increasing_critical" {
 
 # CloudWatch alarm for main queue message count (warning)
 resource "aws_cloudwatch_metric_alarm" "sqs_messages_count_warning" {
-  count = local.cloudwatch_alarms_enabled
-
   alarm_name        = "${local.alarm_name_prefix} - Messages Count Warning"
   alarm_description = "SQS queue ${aws_sqs_queue.queue.name} message count exceeded warning threshold (${var.queue_messages_count_warning_threshold})."
 
@@ -105,8 +99,6 @@ resource "aws_cloudwatch_metric_alarm" "sqs_messages_count_warning" {
 
 # CloudWatch alarm for main queue message count (critical)
 resource "aws_cloudwatch_metric_alarm" "sqs_messages_count_critical" {
-  count = local.cloudwatch_alarms_enabled
-
   alarm_name        = "${local.alarm_name_prefix} - Messages Count Critical"
   alarm_description = "SQS queue ${aws_sqs_queue.queue.name} message count exceeded critical threshold (${var.queue_messages_count_critical_threshold})."
 
@@ -134,8 +126,6 @@ resource "aws_cloudwatch_metric_alarm" "sqs_messages_count_critical" {
 
 # CloudWatch alarm for main queue oldest message age (warning)
 resource "aws_cloudwatch_metric_alarm" "sqs_oldest_message_age_warning" {
-  count = local.cloudwatch_alarms_enabled
-
   alarm_name        = "${local.alarm_name_prefix} - Messages Age Warning"
   alarm_description = "SQS queue ${aws_sqs_queue.queue.name} oldest message age exceeded warning threshold (${var.queue_message_age_threshold_seconds}s)."
 

--- a/aws-sqs-queue/data.tf
+++ b/aws-sqs-queue/data.tf
@@ -3,6 +3,7 @@ data "aws_kms_key" "sqs_encryption_key" {
 }
 
 data "aws_sns_topic" "rootly_oncall" {
-  count = local.cloudwatch_alarms_enabled
-  name  = "alerts-to-rootly"
+  count = local.rootly_enabled ? 1 : 0
+
+  name = "alerts-to-rootly"
 }

--- a/aws-sqs-queue/locals.tf
+++ b/aws-sqs-queue/locals.tf
@@ -2,8 +2,8 @@ locals {
   alarm_name_prefix = "${var.service_name} SQS"
   tags              = merge(var.tags, { Service = var.service_name })
 
-  cloudwatch_alarms_enabled = var.env == "production" ? 1 : 0
+  rootly_enabled = var.env == "production"
 
-  alerts_slack_sns_topic_arns  = local.cloudwatch_alarms_enabled == 1 ? ["arn:aws:sns:us-east-1:637192944017:alerts-to-slack"] : []
-  alerts_rootly_sns_topic_arns = data.aws_sns_topic.rootly_oncall[*].arn
+  alerts_slack_sns_topic_arns  = ["arn:aws:sns:us-east-1:637192944017:alerts-to-slack"]
+  alerts_rootly_sns_topic_arns = local.rootly_enabled ? data.aws_sns_topic.rootly_oncall[*].arn : []
 }


### PR DESCRIPTION
Sem to udělal blbě. Původně jsem je na Devu vypnul, ale měly by chodit do #platforms-warning-dev