### PR TITLE
fix: unique sqs alarm names

### DIFF
--- a/aws-sqs-queue/locals.tf
+++ b/aws-sqs-queue/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  alarm_name_prefix = "${var.service_name} SQS"
+  alarm_name_prefix = "${var.service_name} SQS ${var.queue_name}"
   tags              = merge(var.tags, { Service = var.service_name })
 
   rootly_enabled = var.env == "production"


### PR DESCRIPTION
Názvy alarmů se skládaly jen z toho service name v prefixu, takže když má servisa víc než jednu frontu, tak dostanou stejný název. 

https://github.com/FigurePOS/terraform-modules/blob/8324ef9df57c96fe9c810eff78075d707fa55197/aws-sqs-queue/cloudwatch_alarms.tf#L6

Vytvoří se sice víc alarmů se stejným jménem, jenže to potom generuje drift protože nemají zaručený pořadé a jednou se updatuje první jedna fronta, podruhé druhá fronta a vzájemně se pak přepisují.

<img width="1014" height="501" alt="CleanShot 2026-05-14 at 18 31 49" src="https://github.com/user-attachments/assets/2ff48155-602d-4402-848b-41c5f1a4384b" />
<img width="1038" height="584" alt="CleanShot 2026-05-14 at 18 31 13" src="https://github.com/user-attachments/assets/e38c5605-2da6-4ebc-8f9d-a4c5de78248c" />
