### PR TITLE
chore: decrease cloudwatch logs retency to 3 days

### DIFF
--- a/aws-ecs-service/cloudwatch.tf
+++ b/aws-ecs-service/cloudwatch.tf
@@ -2,5 +2,5 @@ resource "aws_cloudwatch_log_group" "log_group" {
   # checkov:skip=CKV_AWS_158:Log group is not encrypted. TODO
   # checkov:skip=CKV_AWS_338:Ensure CloudWatch log groups retains logs for at least 1 year.
   name              = "/figure/container/${var.service_name}"
-  retention_in_days = 7
+  retention_in_days = 3
 }

--- a/aws-lambda-function/lambda.tf
+++ b/aws-lambda-function/lambda.tf
@@ -39,7 +39,7 @@ resource "aws_s3_object" "lambda_package" {
 resource "aws_cloudwatch_log_group" "lambda" {
   //checkov:skip=CKV_AWS_338: "Ensure CloudWatch log groups retains logs for at least 1 year" - Short platform retention; long-term log archival is handled separately.
   name              = "${local.lambda_log_group_prefix}/${var.function_name}"
-  retention_in_days = 7
+  retention_in_days = 3
   tags              = var.tags
 }
 


### PR DESCRIPTION
imho stačí když jsou ty logy v ECS/Lambda konzoli vidět bezprostředně, stáhnul bych to na 3. (Možná by stačilo i 2 nebo dokonce 1, přehodnotím někdy později podle costů.)