### PR TITLE
fix: http and event monitors FGR3-9342

### DIFF
--- a/datadog-monitor-event-latency/datadog.tf
+++ b/datadog-monitor-event-latency/datadog.tf
@@ -3,8 +3,13 @@ locals {
   slack_warning_handle = var.env == "development" ? "@slack-platform-warnings-dev" : "@slack-platform-warnings"
   monitor_message      = coalesce(var.message, local.slack_warning_handle)
 
-  monitor_dimensions = "env:${var.env},resource_name:${var.resource_name},service:${var.service_name}"
-  metric_latency     = "${var.latency_percentile}:fgr.message.consumer.duration{${local.monitor_dimensions}}"
+  # Datadog indexes OTLP consumer metrics by resource.name (traceSqsMessage opts.resource).
+  monitor_dimensions = join(",", [
+    "env:${var.env}",
+    "resource.name:${var.event_type}",
+    "service:${var.service_name}",
+  ])
+  metric_latency = "${var.latency_percentile}:fgr.message.consumer.duration{${local.monitor_dimensions}}"
 
   monitor_tags = concat(["env:${var.env}", "service:${var.service_name}"], var.tags)
 }
@@ -14,10 +19,10 @@ data "datadog_role" "admin_role" {
 }
 
 resource "datadog_monitor" "event_monitor_latency" {
-  name           = "${var.service_name} – Events - ${var.resource_name} – Latency"
+  name           = "${var.service_name} – Events - ${var.event_type} – Latency"
   type           = "metric alert"
   message        = local.monitor_message
-  query          = "${var.eval_fn}(${var.interval}):${local.metric_latency} > ${var.latency_target}"
+  query          = "${var.latency_eval_fn}(${var.interval}):${local.metric_latency} > ${var.latency_target}"
   notify_no_data = var.notify_on_missing_data
 
   restricted_roles = [data.datadog_role.admin_role.id]

--- a/datadog-monitor-event-latency/variables.tf
+++ b/datadog-monitor-event-latency/variables.tf
@@ -3,14 +3,20 @@ variable "env" {
   type = string
 }
 
-variable "eval_fn" {
-  type    = string
-  default = "min"
+variable "event_type" {
+  type        = string
+  description = "SQS event type passed to traceSqsMessage opts.resource (e.g. ProductUpdated). Must match fgr.message.consumer.* resource.name."
 }
 
 variable "interval" {
   type    = string
   default = "last_10m"
+}
+
+variable "latency_eval_fn" {
+  type        = string
+  default     = "max"
+  description = "Time aggregation for the latency monitor (e.g. avg, max, min). Use max to alert on worst p99 in the window."
 }
 
 variable "latency_percentile" {
@@ -32,11 +38,6 @@ variable "message" {
 variable "notify_on_missing_data" {
   type    = bool
   default = false
-}
-
-variable "resource_name" {
-  type        = string
-  description = "SQS event type (traceSqsMessage opts.resource), e.g. OrderPlaced. Must match fgr.message.consumer.* metric resource.name."
 }
 
 variable "service_name" {

--- a/datadog-monitor-http-endpoint/datadog.tf
+++ b/datadog-monitor-http-endpoint/datadog.tf
@@ -3,10 +3,20 @@ locals {
   slack_warning_handle = var.env == "development" ? "@slack-platform-warnings-dev" : "@slack-platform-warnings"
   monitor_message      = coalesce(var.message, local.slack_warning_handle)
 
-  monitor_dimensions = "env:${var.env},resource_name:\"${var.resource_name}\",service:${var.service_name}"
-  metric_errors      = "sum:fgr.http.server.request.errors{${local.monitor_dimensions}}.as_rate().rollup(sum,60)"
-  metric_hits        = "sum:fgr.http.server.request.count{${local.monitor_dimensions}}.as_rate().rollup(sum,60)"
-  metric_latency     = "${var.latency_percentile}:fgr.http.server.request.duration{${local.monitor_dimensions}}"
+  method_upper        = upper(var.method)
+  resource_name_label = "${local.method_upper} ${var.route}"
+  http_route          = "/${var.api_path_prefix}${var.route}"
+
+  # Datadog indexes OTLP HTTP metrics by http.method and http.route, not resource.name.
+  monitor_dimensions = join(",", [
+    "env:${var.env}",
+    "http.method:${local.method_upper}",
+    "http.route:${local.http_route}",
+    "service:${var.service_name}",
+  ])
+  metric_errors       = "sum:fgr.http.server.request.errors{${local.monitor_dimensions}}.as_rate().rollup(sum,60)"
+  metric_hits         = "sum:fgr.http.server.request.count{${local.monitor_dimensions}}.as_rate().rollup(sum,60)"
+  metric_latency      = "${var.latency_percentile}:fgr.http.server.request.duration{${local.monitor_dimensions}}"
 
   monitor_tags = concat(["env:${var.env}", "service:${var.service_name}"], var.tags)
 }
@@ -16,20 +26,20 @@ data "datadog_role" "admin_role" {
 }
 
 resource "datadog_monitor" "http_monitor_error_rate" {
-  name    = "${var.service_name} – HTTP - ${var.resource_name} - Error rate"
+  name    = "${var.service_name} – HTTP - ${local.resource_name_label} - Error rate"
   type    = "metric alert"
   message = local.monitor_message
-  query   = "${var.eval_fn}(${var.interval}):(100 * ${local.metric_errors} / ${local.metric_hits}) > ${var.error_rate_target}"
+  query   = "${var.error_rate_eval_fn}(${var.interval}):(100 * ${local.metric_errors} / ${local.metric_hits}) > ${var.error_rate_target}"
 
   restricted_roles = [data.datadog_role.admin_role.id]
   tags             = local.monitor_tags
 }
 
 resource "datadog_monitor" "http_monitor_latency" {
-  name           = "${var.service_name} – HTTP - ${var.resource_name} - Latency"
+  name           = "${var.service_name} – HTTP - ${local.resource_name_label} - Latency"
   type           = "metric alert"
   message        = local.monitor_message
-  query          = "${var.eval_fn}(${var.interval}):${local.metric_latency} > ${var.latency_target}"
+  query          = "${var.latency_eval_fn}(${var.interval}):${local.metric_latency} > ${var.latency_target}"
   notify_no_data = var.notify_on_missing_data
 
   restricted_roles = [data.datadog_role.admin_role.id]

--- a/datadog-monitor-http-endpoint/variables.tf
+++ b/datadog-monitor-http-endpoint/variables.tf
@@ -1,20 +1,32 @@
 
+variable "api_path_prefix" {
+  type        = string
+  description = "ALB mount prefix without slashes (e.g. business-config). Combined with route for http.route tag."
+}
+
 variable "env" {
   type = string
+}
+
+variable "error_rate_eval_fn" {
+  type        = string
+  default     = "avg"
+  description = "Time aggregation for the error-rate monitor (e.g. avg, max, min)."
 }
 
 variable "error_rate_target" {
   type = number
 }
 
-variable "eval_fn" {
-  type    = string
-  default = "min"
-}
-
 variable "interval" {
   type    = string
   default = "last_10m"
+}
+
+variable "latency_eval_fn" {
+  type        = string
+  default     = "max"
+  description = "Time aggregation for the latency monitor (e.g. avg, max, min)."
 }
 
 variable "latency_percentile" {
@@ -33,14 +45,24 @@ variable "message" {
   description = "Datadog monitor notification message. Defaults to @slack-platform-warnings-dev in development, @slack-platform-warnings otherwise."
 }
 
+variable "method" {
+  type        = string
+  description = "HTTP method (GET, POST, etc.). Normalized to uppercase in monitor queries."
+}
+
 variable "notify_on_missing_data" {
   type    = bool
   default = false
 }
 
-variable "resource_name" {
+variable "route" {
   type        = string
-  description = "OTLP resource.name tag value for the route (e.g. POST /orders/order/v3). Must match lib-observability HTTP metrics."
+  description = "Route path with leading slash, without api_path_prefix (e.g. /category/match, /location/:id)."
+
+  validation {
+    condition     = startswith(var.route, "/")
+    error_message = "route must start with / (e.g. /category/match)."
+  }
 }
 
 variable "service_name" {


### PR DESCRIPTION
Fix http monitoru podle https://github.com/FigurePOS/lib-observability/pull/6

Plus jsem u něj i u latency monitoru upravil ty defaultní eval funkce, to min tam imho nedávalo moc smysl.