### PR TITLE
fix: query in datadog-monitor-event-latency

### DIFF
--- a/datadog-monitor-event-latency/datadog.tf
+++ b/datadog-monitor-event-latency/datadog.tf
@@ -6,7 +6,7 @@ locals {
   # Datadog indexes OTLP consumer metrics by resource.name (traceSqsMessage opts.resource).
   monitor_dimensions = join(",", [
     "env:${var.env}",
-    "resource.name:lower(${var.event_type})",
+    "resource.name:${lower(var.event_type)}",
     "service:${var.service_name}",
   ])
   metric_latency = "${var.latency_percentile}:fgr.message.consumer.duration{${local.monitor_dimensions}}"


### PR DESCRIPTION
😒 
<img width="1215" height="229" alt="CleanShot 2026-06-08 at 16 34 04" src="https://github.com/user-attachments/assets/ec87ffae-2d4d-4d73-be17-5ab8bb4d424a" />
