### PR TITLE
fix(datadog): metric in http endpoint monitor

### DIFF
--- a/datadog-monitor-http-endpoint/datadog.tf
+++ b/datadog-monitor-http-endpoint/datadog.tf
@@ -5,13 +5,12 @@ locals {
 
   method_upper        = upper(var.method)
   resource_name_label = "${local.method_upper} ${var.route}"
-  http_route          = "/${var.api_path_prefix}${var.route}"
+  http_path           = "/${var.api_path_prefix}${var.route}"
 
-  # Datadog indexes OTLP HTTP metrics by http.method and http.route, not resource.name.
+  # Datadog OTLP metrics use resource.name (e.g. get_/business-config/account).
   monitor_dimensions = join(",", [
     "env:${var.env}",
-    "http.method:${local.method_upper}",
-    "http.route:${local.http_route}",
+    "resource.name:${lower(var.method)}_${local.http_path}",
     "service:${var.service_name}",
   ])
   metric_errors       = "sum:fgr.http.server.request.errors{${local.monitor_dimensions}}.as_rate().rollup(sum,60)"

--- a/datadog-monitor-http-endpoint/variables.tf
+++ b/datadog-monitor-http-endpoint/variables.tf
@@ -1,7 +1,7 @@
 
 variable "api_path_prefix" {
   type        = string
-  description = "ALB mount prefix without slashes (e.g. business-config). Combined with route for http.route tag."
+  description = "ALB mount prefix without slashes (e.g. business-config). Combined with route for resource.name tag."
 }
 
 variable "env" {
@@ -47,7 +47,7 @@ variable "message" {
 
 variable "method" {
   type        = string
-  description = "HTTP method (GET, POST, etc.). Normalized to uppercase in monitor queries."
+  description = "HTTP method (GET, POST, etc.). Used in monitor title and resource.name filter."
 }
 
 variable "notify_on_missing_data" {


### PR DESCRIPTION
Ach jo, při úpravě dashboardu (https://github.com/FigurePOS/terraform-modules/pull/131) jsem zapomněl tady na ten monitor. 🤦‍♂️ Takže opět, http.route v metrikách přestaneme používat, tak je třeba upravit na resource.name