### PR TITLE
feat(sqs): renotify dlq errors after 24h FGR3-9349

### DIFF
--- a/aws-sqs-queue/cloudwatch_alarms.tf
+++ b/aws-sqs-queue/cloudwatch_alarms.tf
@@ -1,5 +1,7 @@
-# CloudWatch alarms for SQS queues (production only).
+# CloudWatch alarms for SQS queues.
 # Warning thresholds notify Slack only; critical thresholds also page on-call via Rootly.
+# DLQ message count: CloudWatch for the initial Slack alert; Datadog re-notifies after the queue
+# has stayed above threshold for dlq_renotify_interval_minutes (default 24h).
 
 # CloudWatch alarm for dead letter queue message count (warning)
 resource "aws_cloudwatch_metric_alarm" "dlq_messages_count_warning" {

--- a/aws-sqs-queue/datadog_monitors.tf
+++ b/aws-sqs-queue/datadog_monitors.tf
@@ -1,0 +1,25 @@
+# Datadog DLQ reminder: first notification only after the count stays above threshold for
+# dlq_renotify_interval_minutes, then re-notifies on the same interval. CloudWatch handles
+# the initial alert.
+
+data "datadog_role" "admin_role" {
+  filter = "Admin"
+}
+
+resource "datadog_monitor" "dlq_messages_count" {
+  name    = "${var.service_name} – SQS – DLQ messages reminder (${var.queue_name})"
+  type    = "metric alert"
+  message = "${local.slack_warning_handle} DLQ still has messages above threshold."
+  query   = "min(last_${var.dlq_renotify_interval_minutes}m):aws.sqs.approximate_number_of_messages_visible{queuename:${lower(aws_sqs_queue.dlq.name)},env:${var.env}} > ${var.dlq_messages_count_threshold}"
+
+  monitor_thresholds {
+    critical = var.dlq_messages_count_threshold
+  }
+
+  notify_no_data      = false
+  renotify_interval   = var.dlq_renotify_interval_minutes
+  renotify_statuses   = ["alert"]
+  require_full_window = false
+  restricted_roles    = [data.datadog_role.admin_role.id]
+  tags                = ["env:${var.env}", "service:${var.service_name}"]
+}

--- a/aws-sqs-queue/locals.tf
+++ b/aws-sqs-queue/locals.tf
@@ -4,6 +4,8 @@ locals {
 
   rootly_enabled = var.env == "production"
 
+  slack_warning_handle = var.env == "development" ? "@slack-platform-warnings-dev" : "@slack-platform-warnings"
+
   alerts_slack_sns_topic_arns  = ["arn:aws:sns:us-east-1:637192944017:alerts-to-slack"]
   alerts_rootly_sns_topic_arns = local.rootly_enabled ? data.aws_sns_topic.rootly_oncall[*].arn : []
 }

--- a/aws-sqs-queue/main.tf
+++ b/aws-sqs-queue/main.tf
@@ -4,5 +4,10 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 6.0"
     }
+
+    datadog = {
+      source  = "datadog/datadog"
+      version = "~> 4.13"
+    }
   }
 }

--- a/aws-sqs-queue/outputs.tf
+++ b/aws-sqs-queue/outputs.tf
@@ -21,3 +21,8 @@ output "queue_name" {
 output "queue_url" {
   value = aws_sqs_queue.queue.url
 }
+
+output "datadog_dlq_messages_monitor_id" {
+  description = "Datadog monitor ID for DLQ message count re-notifications."
+  value       = datadog_monitor.dlq_messages_count.id
+}

--- a/aws-sqs-queue/variables.tf
+++ b/aws-sqs-queue/variables.tf
@@ -22,6 +22,12 @@ variable "deduplication_scope" {
   default     = "queue"
 }
 
+variable "delay_seconds" {
+  type        = number
+  description = "The time in seconds that the delivery of all messages in the queue will be delayed."
+  default     = 0
+}
+
 variable "dlq_messages_count_threshold" {
   type        = number
   description = "The number of messages in the dead letter queue to trigger an alarm."
@@ -39,6 +45,13 @@ variable "dlq_name" {
   description = "The name of the dead letter queue."
   default     = null
 }
+
+variable "dlq_renotify_interval_minutes" {
+  type        = number
+  description = "Minutes the DLQ must stay above threshold before Datadog sends the first reminder, and between subsequent reminders (minutes)."
+  default     = 24 * 60
+}
+
 
 variable "env" {
   type        = string
@@ -107,10 +120,4 @@ variable "tags" {
   type        = map(string)
   description = "Tags to apply to all AWS resources in this module."
   default     = {}
-}
-
-variable "delay_seconds" {
-  type        = number
-  description = "The time in seconds that the delivery of all messages in the queue will be delayed."
-  default     = 0
 }


### PR DESCRIPTION
Vzhledem k tomu že si zatím Datadog necháváme na metriky, tak nejjednodušší způsob jak udělat tu renotifikaci na DLQ alarmy po 24 hodinách je použít Datadog. 😄 První alarm je z CloudWatche, až ty opakované po každých 24 hodinách jsou z Datadogu. 