### PR TITLE
chore: upgrade datadog tf provider + remove legacy monitor restrictions

### DIFF
--- a/aws-sqs-queue/datadog_monitors.tf
+++ b/aws-sqs-queue/datadog_monitors.tf
@@ -2,10 +2,6 @@
 # dlq_renotify_interval_minutes, then re-notifies on the same interval. CloudWatch handles
 # the initial alert.
 
-data "datadog_role" "admin_role" {
-  filter = "Admin"
-}
-
 resource "datadog_monitor" "dlq_messages_count" {
   name    = "${var.service_name} – SQS – DLQ messages reminder (${var.queue_name})"
   type    = "metric alert"
@@ -20,6 +16,6 @@ resource "datadog_monitor" "dlq_messages_count" {
   renotify_interval   = var.dlq_renotify_interval_minutes
   renotify_statuses   = ["alert"]
   require_full_window = false
-  restricted_roles    = [data.datadog_role.admin_role.id]
-  tags                = ["env:${var.env}", "service:${var.service_name}"]
+
+  tags = ["env:${var.env}", "service:${var.service_name}"]
 }

--- a/datadog-dashboard-service/main.tf
+++ b/datadog-dashboard-service/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source = "datadog/datadog"
-      version = "~> 3.31"
+      version = "~> 4.13"
     }
   }
 }

--- a/datadog-monitor-event-latency/datadog.tf
+++ b/datadog-monitor-event-latency/datadog.tf
@@ -25,6 +25,5 @@ resource "datadog_monitor" "event_monitor_latency" {
   query          = "${var.latency_eval_fn}(${var.interval}):${local.metric_latency} > ${var.latency_target}"
   notify_no_data = var.notify_on_missing_data
 
-  restricted_roles = [data.datadog_role.admin_role.id]
-  tags             = local.monitor_tags
+  tags = local.monitor_tags
 }

--- a/datadog-monitor-event-latency/main.tf
+++ b/datadog-monitor-event-latency/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source = "datadog/datadog"
-      version = "~> 3.31"
+      version = "~> 4.13"
     }
   }
 }

--- a/datadog-monitor-http-endpoint/datadog.tf
+++ b/datadog-monitor-http-endpoint/datadog.tf
@@ -20,18 +20,13 @@ locals {
   monitor_tags = concat(["env:${var.env}", "service:${var.service_name}"], var.tags)
 }
 
-data "datadog_role" "admin_role" {
-  filter = "Admin"
-}
-
 resource "datadog_monitor" "http_monitor_error_rate" {
   name    = "${var.service_name} – HTTP - ${local.resource_name_label} - Error rate"
   type    = "metric alert"
   message = local.monitor_message
   query   = "${var.error_rate_eval_fn}(${var.interval}):(100 * ${local.metric_errors} / ${local.metric_hits}) > ${var.error_rate_target}"
 
-  restricted_roles = [data.datadog_role.admin_role.id]
-  tags             = local.monitor_tags
+  tags = local.monitor_tags
 }
 
 resource "datadog_monitor" "http_monitor_latency" {
@@ -41,6 +36,5 @@ resource "datadog_monitor" "http_monitor_latency" {
   query          = "${var.latency_eval_fn}(${var.interval}):${local.metric_latency} > ${var.latency_target}"
   notify_no_data = var.notify_on_missing_data
 
-  restricted_roles = [data.datadog_role.admin_role.id]
-  tags             = local.monitor_tags
+  tags = local.monitor_tags
 }

--- a/datadog-monitor-http-endpoint/main.tf
+++ b/datadog-monitor-http-endpoint/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "datadog/datadog"
-      version = "~> 3.31"
+      version = "~> 4.13"
     }
   }
 }

--- a/datadog-monitor-metric-slo/main.tf
+++ b/datadog-monitor-metric-slo/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source = "datadog/datadog"
-      version = "~> 3.31"
+      version = "~> 4.13"
     }
   }
 }

--- a/datadog-monitor-metric/datadog.tf
+++ b/datadog-monitor-metric/datadog.tf
@@ -1,7 +1,3 @@
-data "datadog_role" "admin_role" {
-  filter = "Admin"
-}
-
 locals {
   monitor_tags = concat(["env:${var.env}", "service:${var.service_name}"], var.tags)
 }
@@ -16,8 +12,7 @@ resource "datadog_monitor" "monitor" {
     critical = var.critical_threshold
   }
 
-  restricted_roles = [data.datadog_role.admin_role.id]
-  tags             = local.monitor_tags
+  tags = local.monitor_tags
 }
 
 output "monitor_id" {

--- a/datadog-monitor-metric/main.tf
+++ b/datadog-monitor-metric/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source = "datadog/datadog"
-      version = "~> 3.31"
+      version = "~> 4.13"
     }
   }
 }


### PR DESCRIPTION
To `restricted_roles` je deprecated a nastavuje se teď nějak složitě přes permissions podobně jako v aws. Nicméně bych to neupravoval na úrovni jednotlivých monitorů, ale poladil bych celou Developer roli.