### PR TITLE
fix: set appProtocol for ecs container port mapping

### DIFF
--- a/aws-ecs-task-definition/ecs.tf
+++ b/aws-ecs-task-definition/ecs.tf
@@ -127,6 +127,7 @@ module "app_container_definition" {
       name          = "http"
       containerPort = var.service_port
       hostPort      = var.service_port
+      appProtocol   = "http"
       protocol      = "tcp"
     }
   ]


### PR DESCRIPTION
Mohlo by vyřešit ECONNRESET při deploymentech.

<img width="1614" height="280" alt="image" src="https://github.com/user-attachments/assets/3d4da1f0-1f03-4218-80af-64ddb2a02ea4" />
<img width="1596" height="992" alt="image" src="https://github.com/user-attachments/assets/b2c4c1b1-a694-4777-a2d1-e76153678b57" />
